### PR TITLE
Add prompt to reuse repels

### DIFF
--- a/data/scripts/repel.inc
+++ b/data/scripts/repel.inc
@@ -1,6 +1,35 @@
 EventScript_RepelWoreOff::
-	msgbox Text_RepelWoreOff, MSGBOX_SIGN
-	end
+        lockall
+        checkitem ITEM_MAX_REPEL
+        goto_if_eq VAR_RESULT, TRUE, EventScript_RepelAsk
+        checkitem ITEM_SUPER_REPEL
+        goto_if_eq VAR_RESULT, TRUE, EventScript_RepelAsk
+        checkitem ITEM_REPEL
+        goto_if_eq VAR_RESULT, TRUE, EventScript_RepelAsk
+        msgbox Text_RepelWoreOff, MSGBOX_SIGN
+        releaseall
+        end
+
+EventScript_RepelAsk:
+        msgbox Text_RepelWoreOffUseAnother, MSGBOX_YESNO
+        goto_if_eq VAR_RESULT, YES, EventScript_UseRepel
+        releaseall
+        end
+
+EventScript_UseRepel:
+        special TryUseNextRepel
+        goto_if_eq VAR_RESULT, FALSE, EventScript_NoRepel
+        msgbox gText_UsedVar2WildRepelled, MSGBOX_DEFAULT
+        releaseall
+        end
+
+EventScript_NoRepel:
+        msgbox Text_RepelWoreOff, MSGBOX_SIGN
+        releaseall
+        end
 
 Text_RepelWoreOff:
-	.string "REPEL's effect wore off…$"
+        .string "REPEL's effect wore off…$"
+
+Text_RepelWoreOffUseAnother:
+        .string "REPEL's effect wore off.\pWould you like to use another?$"

--- a/data/specials.inc
+++ b/data/specials.inc
@@ -219,10 +219,11 @@ gSpecials::
 	def_special EnterSafariMode
 	def_special ExitSafariMode
 	def_special GetPokeblockFeederInFront
-	def_special OpenPokeblockCaseOnFeeder
-	def_special IsMirageIslandPresent
-	def_special UpdateShoalTideFlag
-	def_special InitBirchState
+        def_special OpenPokeblockCaseOnFeeder
+        def_special IsMirageIslandPresent
+        def_special UpdateShoalTideFlag
+        def_special TryUseNextRepel
+        def_special InitBirchState
 	def_special ScriptGetPokedexInfo
 	def_special ShowPokedexRatingMessage
 	def_special DoPCTurnOnEffect

--- a/include/wild_encounter.h
+++ b/include/wild_encounter.h
@@ -36,5 +36,6 @@ void FishingWildEncounter(u8 rod);
 u16 GetLocalWildMon(bool8 *isWaterMon);
 u16 GetLocalWaterMon(void);
 bool8 UpdateRepelCounter(void);
+void TryUseNextRepel(void);
 
 #endif // GUARD_WILD_ENCOUNTER_H

--- a/src/wild_encounter.c
+++ b/src/wild_encounter.c
@@ -16,6 +16,9 @@
 #include "script.h"
 #include "battle_pike.h"
 #include "battle_pyramid.h"
+#include "item.h"
+#include "item_menu.h"
+#include "sound.h"
 #include "constants/abilities.h"
 #include "constants/game_stat.h"
 #include "constants/items.h"
@@ -964,4 +967,28 @@ static void ApplyCleanseTagEncounterRateMod(u32 *encRate)
 {
     if (GetMonData(&gPlayerParty[0], MON_DATA_HELD_ITEM) == ITEM_CLEANSE_TAG)
         *encRate = *encRate * 2 / 3;
+}
+
+void TryUseNextRepel(void)
+{
+    u16 itemId;
+
+    if (CheckBagHasItem(ITEM_MAX_REPEL, 1))
+        itemId = ITEM_MAX_REPEL;
+    else if (CheckBagHasItem(ITEM_SUPER_REPEL, 1))
+        itemId = ITEM_SUPER_REPEL;
+    else if (CheckBagHasItem(ITEM_REPEL, 1))
+        itemId = ITEM_REPEL;
+    else
+    {
+        gSpecialVar_Result = FALSE;
+        return;
+    }
+
+    VarSet(VAR_REPEL_STEP_COUNT, GetItemHoldEffectParam(itemId));
+    RemoveBagItem(itemId, 1);
+    gSpecialVar_ItemId = itemId;
+    CopyItemName(itemId, gStringVar2);
+    PlaySE(SE_REPEL);
+    gSpecialVar_Result = TRUE;
 }


### PR DESCRIPTION
## Summary
- add TryUseNextRepel special to consume the best repel automatically
- prompt player to use another repel when the effect wears off

## Testing
- `make` *(fails: arm-none-eabi-as not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bab4d94a08329b2b95728807990ab