### PR TITLE
Handle overworld poison without fainting

### DIFF
--- a/include/strings.h
+++ b/include/strings.h
@@ -180,6 +180,7 @@ extern const u8 gText_Confirm3[];
 extern const u8 gText_Cancel4[];
 extern const u8 gText_IsThisTheCorrectTime[];
 extern const u8 gText_PkmnFainted_FldPsn[];
+extern const u8 gText_PkmnRecoveredFromPoison[];
 extern const u8 gText_Coins[];
 extern const u8 gText_Silver[];
 extern const u8 gText_Gold[];

--- a/src/field_poison.c
+++ b/src/field_poison.c
@@ -43,9 +43,11 @@ static void FaintFromFieldPoison(u8 partyIdx)
 {
     struct Pokemon *pokemon = &gPlayerParty[partyIdx];
     u32 status = STATUS1_NONE;
+    u32 hp = 1;
 
-    AdjustFriendship(pokemon, FRIENDSHIP_EVENT_FAINT_FIELD_PSN);
+    // Prevent fainting, cure poison, and leave the Pokémon at 1 HP
     SetMonData(pokemon, MON_DATA_STATUS, &status);
+    SetMonData(pokemon, MON_DATA_HP, &hp);
     GetMonData(pokemon, MON_DATA_NICKNAME, gStringVar1);
     StringGet_Nickname(gStringVar1);
 }
@@ -73,7 +75,7 @@ static void Task_TryFieldPoisonWhiteOut(u8 taskId)
             if (MonFaintedFromPoison(tPartyIdx))
             {
                 FaintFromFieldPoison(tPartyIdx);
-                ShowFieldMessage(gText_PkmnFainted_FldPsn);
+                ShowFieldMessage(gText_PkmnRecoveredFromPoison);
                 tState++;
                 return;
             }

--- a/src/strings.c
+++ b/src/strings.c
@@ -1187,6 +1187,7 @@ const u8 gText_IcePunch48BP[] = _("ICE PUNCH{CLEAR_TO 0x4E}48BP");
 const u8 gText_ThunderPunch48BP[] = _("THUNDERPUNCH{CLEAR_TO 0x4E}48BP");
 const u8 gText_FirePunch48BP[] = _("FIRE PUNCH{CLEAR_TO 0x4E}48BP");
 const u8 gText_PkmnFainted_FldPsn[] = _("{STR_VAR_1} fainted…\p\n");
+const u8 gText_PkmnRecoveredFromPoison[] = _("{STR_VAR_1} recovered from poisoning!\p\n");
 const u8 gText_Marco[] = _("MARCO");
 const u8 gText_TrainerCardName[] = _("NAME: ");
 const u8 gText_TrainerCardIDNo[] = _("IDNo.");


### PR DESCRIPTION
## Summary
- keep Pokémon at 1 HP when overworld poison damage would KO
- cure the poison and show a recovery message

## Testing
- `make -j$(nproc)` *(fails: `arm-none-eabi-as: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687bb12aaef883298d0cf92711fda5a9