### PR TITLE
Enable running indoors

### DIFF
--- a/src/bike.c
+++ b/src/bike.c
@@ -892,7 +892,7 @@ static u8 GetBikeCollisionAt(struct ObjectEvent *objectEvent, s16 x, s16 y, u8 d
 
 bool8 RS_IsRunningDisallowed(u8 tile)
 {
-    if (IsRunningDisallowedByMetatile(tile) != FALSE || gMapHeader.mapType == MAP_TYPE_INDOOR)
+    if (IsRunningDisallowedByMetatile(tile) != FALSE)
         return TRUE;
     else
         return FALSE;
@@ -1055,7 +1055,7 @@ void Bike_HandleBumpySlopeJump(void)
 
 bool32 IsRunningDisallowed(u8 metatile)
 {
-    if (!gMapHeader.allowRunning || IsRunningDisallowedByMetatile(metatile) == TRUE)
+    if (IsRunningDisallowedByMetatile(metatile) == TRUE)
         return TRUE;
     else
         return FALSE;


### PR DESCRIPTION
## Summary
- remove the indoor map restriction from `IsRunningDisallowed`
- update `RS_IsRunningDisallowed` to ignore map type

## Testing
- `make -j2` *(fails: `arm-none-eabi-as` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bc156fa4083299e359a759ec54e9c