### PR TITLE
Enable e-reader support

### DIFF
--- a/src/main_menu.c
+++ b/src/main_menu.c
@@ -644,6 +644,8 @@ static void Task_MainMenuCheckSaveFile(u8 taskId)
                 tMenuType = HAS_SAVED_GAME;
                 if (IsMysteryGiftEnabled())
                     tMenuType++;
+                if (IsMysteryEventEnabled())
+                    tMenuType++;
                 gTasks[taskId].func = Task_MainMenuCheckBattery;
                 break;
             case SAVE_STATUS_CORRUPT:
@@ -656,6 +658,8 @@ static void Task_MainMenuCheckSaveFile(u8 taskId)
                 gTasks[taskId].func = Task_WaitForSaveFileErrorWindow;
                 tMenuType = HAS_SAVED_GAME;
                 if (IsMysteryGiftEnabled() == TRUE)
+                    tMenuType++;
+                if (IsMysteryEventEnabled() == TRUE)
                     tMenuType++;
                 break;
             case SAVE_STATUS_EMPTY:

--- a/src/new_game.c
+++ b/src/new_game.c
@@ -204,6 +204,8 @@ void NewGameInitData(void)
     WipeTrainerNameRecords();
     ResetTrainerHillResults();
     ResetContestLinkResults();
+    EnableMysteryGift();
+    EnableMysteryEvent();
 }
 
 static void ResetMiniGamesRecords(void)


### PR DESCRIPTION
## Summary
- enable e-reader features in new game initialization
- show the Mystery Events menu when the feature is enabled

## Testing
- `make -j2` *(fails: arm-none-eabi-as not found)*
- `sudo apt-get update` *(fails: repository signatures not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bc4be83f083299ecb9ed3514141b1