### PR TITLE
Add PC memory buffer support

### DIFF
--- a/include/gba/defines.h
+++ b/include/gba/defines.h
@@ -6,10 +6,17 @@
 #define TRUE  1
 #define FALSE 0
 
+#ifdef PC
+#define IWRAM_DATA static
+#define EWRAM_DATA static
+#define COMMON_DATA static
+#define UNUSED __attribute__((unused))
+#else
 #define IWRAM_DATA __attribute__((section("iwram_data")))
 #define EWRAM_DATA __attribute__((section("ewram_data")))
 #define COMMON_DATA __attribute__((section("common_data")))
 #define UNUSED __attribute__((unused))
+#endif
 
 #if MODERN
 #define NOINLINE __attribute__((noinline))
@@ -28,6 +35,7 @@
 #define IWRAM_START 0x03000000
 #define IWRAM_END   (IWRAM_START + 0x8000)
 
+#ifndef PC
 #define PLTT          0x5000000
 #define BG_PLTT       PLTT
 #define BG_PLTT_SIZE  0x200
@@ -60,6 +68,45 @@
 
 #define OAM      0x7000000
 #define OAM_SIZE 0x400
+#else
+extern u8 *gPCPltt;
+extern u8 *gPCVram;
+extern u8 *gPCOam;
+
+#define BG_PLTT_SIZE  0x200
+#define OBJ_PLTT_SIZE 0x200
+#define PLTT_SIZE     (BG_PLTT_SIZE + OBJ_PLTT_SIZE)
+
+#define PLTT          gPCPltt
+#define BG_PLTT       gPCPltt
+#define OBJ_PLTT      (gPCPltt + BG_PLTT_SIZE)
+
+#define VRAM      gPCVram
+#define VRAM_SIZE 0x18000
+
+#define BG_VRAM           gPCVram
+#define BG_VRAM_SIZE      0x10000
+#define BG_CHAR_SIZE      0x4000
+#define BG_SCREEN_SIZE    0x800
+#define BG_CHAR_ADDR(n)   (gPCVram + (BG_CHAR_SIZE * (n)))
+#define BG_SCREEN_ADDR(n) (gPCVram + (BG_SCREEN_SIZE * (n)))
+
+#define BG_TILE_H_FLIP(n) (0x400 + (n))
+#define BG_TILE_V_FLIP(n) (0x800 + (n))
+
+#define NUM_BACKGROUNDS 4
+
+// text-mode BG
+#define OBJ_VRAM0      (gPCVram + 0x10000)
+#define OBJ_VRAM0_SIZE 0x8000
+
+// bitmap-mode BG
+#define OBJ_VRAM1      (gPCVram + 0x14000)
+#define OBJ_VRAM1_SIZE 0x4000
+
+#define OAM      gPCOam
+#define OAM_SIZE 0x400
+#endif
 
 #define ROM_HEADER_SIZE   0xC0
 

--- a/src/main.c
+++ b/src/main.c
@@ -24,6 +24,9 @@
 #include "main.h"
 #include "trainer_hill.h"
 #include "constants/rgb.h"
+#ifdef PC
+#include <stdlib.h>
+#endif
 
 static void VBlankIntr(void);
 static void HBlankIntr(void);
@@ -69,6 +72,12 @@ COMMON_DATA u8 gLinkVSyncDisabled = 0;
 COMMON_DATA u32 IntrMain_Buffer[0x200] = {0};
 COMMON_DATA s8 gPcmDmaCounter = 0;
 
+#ifdef PC
+u8 *gPCVram;
+u8 *gPCPltt;
+u8 *gPCOam;
+#endif
+
 static EWRAM_DATA u16 sTrainerId = 0;
 
 //EWRAM_DATA void (**gFlashTimerIntrFunc)(void) = NULL;
@@ -93,6 +102,11 @@ void AgbMain(void)
 #if !MODERN
     RegisterRamReset(RESET_ALL);
 #endif //MODERN
+#ifdef PC
+    gPCVram = malloc(VRAM_SIZE);
+    gPCPltt = malloc(PLTT_SIZE);
+    gPCOam = malloc(OAM_SIZE);
+#endif
     *(vu16 *)BG_PLTT = RGB_WHITE; // Set the backdrop to white on startup
     InitGpuRegManager();
     REG_WAITCNT = WAITCNT_PREFETCH_ENABLE | WAITCNT_WS0_S_1 | WAITCNT_WS0_N_3;

--- a/src/palette.c
+++ b/src/palette.c
@@ -5,6 +5,9 @@
 #include "gpu_regs.h"
 #include "task.h"
 #include "constants/rgb.h"
+#ifdef PC
+#include <string.h>
+#endif
 
 enum
 {
@@ -106,7 +109,11 @@ void TransferPlttBuffer(void)
     {
         void *src = gPlttBufferFaded;
         void *dest = (void *)PLTT;
+#ifdef PC
+        memcpy(dest, src, PLTT_SIZE);
+#else
         DmaCopy16(3, src, dest, PLTT_SIZE);
+#endif
         sPlttBufferTransferPending = FALSE;
         if (gPaletteFade.mode == HARDWARE_FADE && gPaletteFade.active)
             UpdateBlendRegisters();
@@ -145,14 +152,18 @@ void ResetPaletteFade(void)
 
 static void ReadPlttIntoBuffers(void)
 {
-    u16 i;
     u16 *pltt = (u16 *)PLTT;
-
+#ifdef PC
+    memcpy(gPlttBufferUnfaded, pltt, PLTT_SIZE);
+    memcpy(gPlttBufferFaded, pltt, PLTT_SIZE);
+#else
+    u16 i;
     for (i = 0; i < PLTT_BUFFER_SIZE; i++)
     {
         gPlttBufferUnfaded[i] = pltt[i];
         gPlttBufferFaded[i] = pltt[i];
     }
+#endif
 }
 
 bool8 BeginNormalPaletteFade(u32 selectedPalettes, s8 delay, u8 startY, u8 targetY, u16 blendColor)


### PR DESCRIPTION
## Summary
- Add desktop definitions for EWRAM/IWRAM/COMMON_DATA macros
- Replace fixed VRAM/PLTT/OAM addresses with dynamically allocated buffers on PC
- Use host memory copies for palette transfers when building for PC

## Testing
- `make tidy`
- `make` *(fails: arm-none-eabi-as: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0639c74083298ee9321239617df2