### PR TITLE
Enable desktop PC build of game

### DIFF
--- a/include/global.h
+++ b/include/global.h
@@ -3,6 +3,7 @@
 
 #include <string.h>
 #include <limits.h>
+#include <stdint.h>
 #include "config.h" // we need to define config before gba headers as print stuff needs the functions nulled before defines.
 #include "platform.h" // Select PC or GBA specific code paths
 #include "gba/gba.h"
@@ -112,13 +113,13 @@
 #define T1_READ_8(ptr)  ((ptr)[0])
 #define T1_READ_16(ptr) ((ptr)[0] | ((ptr)[1] << 8))
 #define T1_READ_32(ptr) ((ptr)[0] | ((ptr)[1] << 8) | ((ptr)[2] << 16) | ((ptr)[3] << 24))
-#define T1_READ_PTR(ptr) (u8 *) T1_READ_32(ptr)
+#define T1_READ_PTR(ptr) (u8 *)(uintptr_t)T1_READ_32(ptr)
 
 // T2_READ_8 is a duplicate to remain consistent with each group.
 #define T2_READ_8(ptr)  ((ptr)[0])
 #define T2_READ_16(ptr) ((ptr)[0] + ((ptr)[1] << 8))
 #define T2_READ_32(ptr) ((ptr)[0] + ((ptr)[1] << 8) + ((ptr)[2] << 16) + ((ptr)[3] << 24))
-#define T2_READ_PTR(ptr) (void *) T2_READ_32(ptr)
+#define T2_READ_PTR(ptr) (void *)(uintptr_t)T2_READ_32(ptr)
 
 #define PACK(data, shift, mask)   ( ((data) << (shift)) & (mask) )
 #define UNPACK(data, shift, mask) ( ((data) & (mask)) >> (shift) )

--- a/src/pc_m4a.c
+++ b/src/pc_m4a.c
@@ -1,0 +1,22 @@
+#include "m4a.h"
+#ifdef PLATFORM_PC
+struct MusicPlayerInfo gMPlayInfo_BGM;
+struct MusicPlayerInfo gMPlayInfo_SE1;
+struct MusicPlayerInfo gMPlayInfo_SE2;
+struct MusicPlayerInfo gMPlayInfo_SE3;
+struct SoundInfo gSoundInfo;
+
+void m4aSoundVSync(void) {}
+void m4aSoundVSyncOn(void) {}
+void m4aSoundInit(void) {}
+void m4aSoundMain(void) {}
+void m4aSongNumStart(u16 n) {(void)n;}
+void m4aSongNumStartOrChange(u16 n) {(void)n;}
+void m4aSongNumStop(u16 n) {(void)n;}
+void m4aMPlayAllStop(void) {}
+void m4aMPlayContinue(struct MusicPlayerInfo *mplayInfo) {(void)mplayInfo;}
+void m4aMPlayFadeOut(struct MusicPlayerInfo *mplayInfo, u16 speed) {(void)mplayInfo; (void)speed;}
+void m4aMPlayFadeOutTemporarily(struct MusicPlayerInfo *mplayInfo, u16 speed) {(void)mplayInfo; (void)speed;}
+void m4aMPlayFadeIn(struct MusicPlayerInfo *mplayInfo, u16 speed) {(void)mplayInfo; (void)speed;}
+void m4aMPlayImmInit(struct MusicPlayerInfo *mplayInfo) {(void)mplayInfo;}
+#endif

--- a/src/pc_main.c
+++ b/src/pc_main.c
@@ -1,0 +1,11 @@
+#include "global.h"
+#include "main.h"
+
+#ifdef PLATFORM_PC
+int main(void)
+{
+    AgbMain();
+    return 0;
+}
+#endif
+


### PR DESCRIPTION
## Summary
- add PC object list and build rules to compile sources with host compiler when `PLATFORM_PC` is defined
- include entry point `pc_main.c` to call `AgbMain` for desktop builds
- cast script pointer macros through `uintptr_t` and stub out m4a for PC platform

## Testing
- `make tools`
- `make generated`
- `make pc` *(fails: size of array `SaveBlock1FreeSpace` is negative)*

------
https://chatgpt.com/codex/tasks/task_e_68bba32e09c08329b21d1e73a68186d7