### PR TITLE
Add desktop save file support

### DIFF
--- a/src/agb_flash.c
+++ b/src/agb_flash.c
@@ -1,3 +1,5 @@
+#include "platform.h"
+#if PLATFORM_GBA
 #include "gba/gba.h"
 #include "gba/flash_internal.h"
 
@@ -294,3 +296,5 @@ u32 ProgramFlashSectorAndVerifyNBytes(u16 sectorNum, u8 *src, u32 n)
 
     return result;
 }
+
+#endif // PLATFORM_GBA

--- a/src/agb_flash_1m.c
+++ b/src/agb_flash_1m.c
@@ -1,3 +1,5 @@
+#include "platform.h"
+#if PLATFORM_GBA
 #include "gba/gba.h"
 #include "gba/flash_internal.h"
 
@@ -48,6 +50,8 @@ u16 IdentifyFlash(void)
     return result;
 }
 
+#endif // PLATFORM_GBA
+
 u16 WaitForFlashWrite_Common(u8 phase, u8 *addr, u8 lastData)
 {
     u16 result = 0;
@@ -84,3 +88,5 @@ u16 WaitForFlashWrite_Common(u8 phase, u8 *addr, u8 lastData)
 
     return result;
 }
+
+#endif // PLATFORM_GBA

--- a/src/agb_flash_le.c
+++ b/src/agb_flash_le.c
@@ -1,3 +1,5 @@
+#include "platform.h"
+#if PLATFORM_GBA
 #include "gba/gba.h"
 #include "gba/flash_internal.h"
 
@@ -29,3 +31,5 @@ const struct FlashSetupInfo LE26FV10N1TS =
         { { 0x62, 0x13 } } // ID
     }
 };
+
+#endif // PLATFORM_GBA

--- a/src/agb_flash_mx.c
+++ b/src/agb_flash_mx.c
@@ -1,3 +1,5 @@
+#include "platform.h"
+#if PLATFORM_GBA
 #include "gba/gba.h"
 #include "gba/flash_internal.h"
 
@@ -73,6 +75,7 @@ u16 EraseFlashChip_MX(void)
 
     return result;
 }
+
 
 u16 EraseFlashSector_MX(u16 sectorNum)
 {
@@ -191,3 +194,5 @@ u16 ProgramFlashSector_MX(u16 sectorNum, u8 *src)
 
     return result;
 }
+
+#endif // PLATFORM_GBA

--- a/src/pc_flash.c
+++ b/src/pc_flash.c
@@ -1,0 +1,101 @@
+#include "global.h"
+#include "save.h"
+#include "gba/flash_internal.h"
+#include "agb_flash.h"
+
+#ifdef PLATFORM_PC
+#include <stdio.h>
+#include <string.h>
+
+#define SAVE_FILE "pokeemerald.sav"
+
+static u8 sFlashMemory[SECTORS_COUNT * SECTOR_SIZE];
+
+// Required global variables from flash_internal.h
+u16 gFlashNumRemainingBytes;
+u16 (*ProgramFlashByte)(u16, u32, u8);
+u16 (*ProgramFlashSector)(u16, u8 *);
+u16 (*EraseFlashChip)(void);
+u16 (*EraseFlashSector)(u16);
+u16 (*WaitForFlashWrite)(u8, u8 *, u8);
+const u16 *gFlashMaxTime;
+const struct FlashType *gFlash;
+u8 (*PollFlashStatus)(u8 *);
+u8 gFlashTimeoutFlag;
+
+static u16 ProgramFlashByte_PC(u16 sectorNum, u32 offset, u8 data);
+static u16 ProgramFlashSector_PC(u16 sectorNum, u8 *src);
+static u16 EraseFlashSector_PC(u16 sectorNum);
+
+static void FlushFlashMemory(void)
+{
+    FILE *file = fopen(SAVE_FILE, "wb");
+    if (file != NULL)
+    {
+        fwrite(sFlashMemory, 1, sizeof(sFlashMemory), file);
+        fclose(file);
+    }
+}
+
+static void LoadFlashMemory(void)
+{
+    FILE *file = fopen(SAVE_FILE, "rb");
+    if (file != NULL)
+    {
+        fread(sFlashMemory, 1, sizeof(sFlashMemory), file);
+        fclose(file);
+    }
+    else
+    {
+        memset(sFlashMemory, 0xFF, sizeof(sFlashMemory));
+    }
+}
+
+u16 SetFlashTimerIntr(u8 timerNum, void (**intrFunc)(void))
+{
+    (void)timerNum;
+    (void)intrFunc;
+    return 0;
+}
+
+u16 IdentifyFlash(void)
+{
+    LoadFlashMemory();
+    ProgramFlashByte = ProgramFlashByte_PC;
+    ProgramFlashSector = ProgramFlashSector_PC;
+    EraseFlashSector = EraseFlashSector_PC;
+    return 0;
+}
+
+void ReadFlash(u16 sectorNum, u32 offset, u8 *dest, u32 size)
+{
+    memcpy(dest, sFlashMemory + sectorNum * SECTOR_SIZE + offset, size);
+}
+
+u16 ProgramFlashByte_PC(u16 sectorNum, u32 offset, u8 data)
+{
+    sFlashMemory[sectorNum * SECTOR_SIZE + offset] = data;
+    FlushFlashMemory();
+    return 0;
+}
+
+u16 EraseFlashSector_PC(u16 sectorNum)
+{
+    memset(sFlashMemory + sectorNum * SECTOR_SIZE, 0xFF, SECTOR_SIZE);
+    FlushFlashMemory();
+    return 0;
+}
+
+u16 ProgramFlashSector_PC(u16 sectorNum, u8 *src)
+{
+    memcpy(sFlashMemory + sectorNum * SECTOR_SIZE, src, SECTOR_SIZE);
+    FlushFlashMemory();
+    return 0;
+}
+
+u32 ProgramFlashSectorAndVerify(u16 sectorNum, u8 *src)
+{
+    return ProgramFlashSector_PC(sectorNum, src);
+}
+
+#endif // PLATFORM_PC


### PR DESCRIPTION
## Summary
- Add `pc_flash` module that reads and writes GBA flash sectors from a `pokeemerald.sav` file when running on a PC
- Guard existing flash-specific sources so they only build for GBA hardware

## Testing
- `make pc` *(fails: map_groups.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bbac0541e88329b85215e662f21d35