### PR TITLE
Improve SDL audio error handling and thread safety

### DIFF
--- a/include/gba/m4a_internal.h
+++ b/include/gba/m4a_internal.h
@@ -310,6 +310,10 @@ struct MusicPlayerTrack
     u32 unk_3C;
     u8 *cmdPtr;
     u8 *patternStack[3];
+#if PLATFORM_PC
+    s16 pitch;
+    u8 modDepth;
+#endif
 };
 
 #define MUSICPLAYER_STATUS_TRACK 0x0000ffff


### PR DESCRIPTION
## Summary
- handle SDL audio initialization errors and ensure devices are closed on shutdown
- guard audio state with SDL_LockAudioDevice to avoid races
- define pitch and modDepth fields for PC MusicPlayerTrack to satisfy PC build

## Testing
- `make pc` *(fails: map_groups.h missing, SDL2 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bbccd046d083298dd718169d0c8f18