### PR TITLE
Implement fallback m4aSoundMain when SDL unavailable

### DIFF
--- a/src/m4a.c
+++ b/src/m4a.c
@@ -2124,7 +2124,28 @@ void m4aSoundInit(void)
 #endif
 }
 
-void m4aSoundMain(void) {}
+void m4aSoundMain(void)
+{
+#if defined(USE_SDL)
+    // When an SDL audio device is active, SoundMain is driven by the
+    // SdlAudioCallback. If the device failed to open, fall back to
+    // manually pumping SoundMain here.
+    if (sAudioDevice == 0)
+#endif
+    {
+        struct SoundInfo *soundInfo = SOUND_INFO_PTR;
+
+        AUDIO_LOCK();
+        SoundMain();
+
+        if (soundInfo->pcmDmaCounter)
+            soundInfo->pcmDmaCounter--;
+        else
+            soundInfo->pcmDmaCounter = soundInfo->pcmDmaPeriod;
+
+        AUDIO_UNLOCK();
+    }
+}
 
 void m4aSoundMode(u32 mode)
 {


### PR DESCRIPTION
## Summary
- Call `SoundMain` from `m4aSoundMain` when no SDL audio device is active, ensuring audio state updates without SDL callbacks

## Testing
- `make tools`
- `make generated`
- `make pc` *(fails: build interrupted due to resource constraints)*

------
https://chatgpt.com/codex/tasks/task_e_68bbd6f781d08329b4f38d6946d9a301