### PR TITLE
Implement PC sound driver wrappers

### DIFF
--- a/libagbsyscall/libagbsyscall.c
+++ b/libagbsyscall/libagbsyscall.c
@@ -2,6 +2,10 @@
 
 #ifndef GBA
 
+#ifdef PLATFORM_PC
+#include "m4a.h"
+#endif
+
 // NOTE: These are minimal desktop stubs for GBA BIOS syscalls.
 // TODO: Provide high-level implementations where appropriate.
 
@@ -208,50 +212,63 @@ __attribute__((weak)) u32 MidiKey2Freq(u8 key, u8 fractional, u8 octave)
     return 0;
 }
 
-__attribute__((weak)) void SoundDriverInit(void)
+void SoundDriverInit(void)
 {
-    // TODO: Initialize sound driver.
+#ifdef PLATFORM_PC
+    m4aSoundInit();
+#endif
 }
 
-__attribute__((weak)) void SoundDriverMain(void)
+void SoundDriverMain(void)
 {
-    // TODO: Run sound driver main routine.
+#ifdef PLATFORM_PC
+    m4aSoundMain();
+#endif
 }
 
-__attribute__((weak)) void SoundDriverVSync(void)
+void SoundDriverVSync(void)
 {
-    // TODO: Update sound driver during VBlank.
+#ifdef PLATFORM_PC
+    m4aSoundVSync();
+#endif
 }
 
-__attribute__((weak)) void SoundDriverVSyncOff(void)
+void SoundDriverVSyncOff(void)
 {
-    // TODO: Disable sound driver VBlank synchronization.
+#ifdef PLATFORM_PC
+    m4aSoundVSyncOff();
+#endif
 }
 
-__attribute__((weak)) void SoundDriverVSyncOn(void)
+void SoundDriverVSyncOn(void)
 {
-    // TODO: Enable sound driver VBlank synchronization.
+#ifdef PLATFORM_PC
+    m4aSoundVSyncOn();
+#endif
 }
 
-__attribute__((weak)) void SoundDriverMode(u32 mode)
+void SoundDriverMode(u32 mode)
 {
+#ifdef PLATFORM_PC
+    m4aSoundMode(mode);
+#else
     (void)mode;
-    // TODO: Configure sound driver mode.
+#endif
 }
 
-__attribute__((weak)) void SoundBiasSet(void)
+void SoundBiasSet(void)
 {
-    // TODO: Set sound bias register.
+    // No-op on PC.
 }
 
-__attribute__((weak)) void SoundBiasReset(void)
+void SoundBiasReset(void)
 {
-    // TODO: Reset sound bias register.
+    // No-op on PC.
 }
 
-__attribute__((weak)) void SoundBiasChange(void)
+void SoundBiasChange(void)
 {
-    // TODO: Gradually change sound bias.
+    // No-op on PC.
 }
 
 __attribute__((weak)) void MusicPlayerOpen(void)

--- a/src/pc_bios.c
+++ b/src/pc_bios.c
@@ -194,48 +194,6 @@ s32 Div(s32 num, s32 denom)
     return num / denom;
 }
 
-void SoundDriverInit(void)
-{
-    m4aSoundInit();
-}
-
-void SoundDriverMain(void)
-{
-    m4aSoundMain();
-}
-
-void SoundDriverVSync(void)
-{
-    m4aSoundVSync();
-}
-
-void SoundDriverVSyncOff(void)
-{
-    m4aSoundVSyncOff();
-}
-
-void SoundDriverVSyncOn(void)
-{
-    m4aSoundVSyncOn();
-}
-
-void SoundDriverMode(u32 mode)
-{
-    m4aSoundMode(mode);
-}
-
-void SoundBiasReset(void)
-{
-}
-
-void SoundBiasSet(void)
-{
-}
-
-void SoundBiasChange(void)
-{
-}
-
 #else
 #error "PLATFORM_PC must be defined"
 #endif // PLATFORM_PC


### PR DESCRIPTION
## Summary
- forward SoundDriver* calls to m4a functions in desktop syscall stubs
- drop redundant sound driver stubs from pc_bios

## Testing
- `gcc -DPLATFORM_PC -c libagbsyscall/libagbsyscall.c -Iinclude -o /tmp/libagbsyscall.o`
- `gcc -DPLATFORM_PC -c src/pc_bios.c -Iinclude -o /tmp/pc_bios.o`
- `make -C libagbsyscall` *(fails: arm-none-eabi-as: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bbdbfcc24883299c20928a6afa9b59