### PR TITLE
Make ident fields volatile for sound info

### DIFF
--- a/include/gba/m4a_internal.h
+++ b/include/gba/m4a_internal.h
@@ -188,7 +188,7 @@ struct SoundInfo
     // values during sensitive operations for locking purposes.
     // This field should be volatile but isn't. This could potentially cause
     // race conditions.
-    u32 ident;
+    volatile u32 ident;
 
     vu8 pcmDmaCounter;
 
@@ -348,7 +348,7 @@ struct MusicPlayerInfo
     u16 fadeOV;
     struct MusicPlayerTrack *tracks;
     struct ToneData *tone;
-    u32 ident;
+    volatile u32 ident;
     MPlayMainFunc MPlayMainNext;
     struct MusicPlayerInfo *musicPlayerNext;
 };

--- a/src/m4a.c
+++ b/src/m4a.c
@@ -1810,6 +1810,7 @@ struct PokemonCrySong gPokemonCrySong;
 u8 gMPlayMemAccArea[0x10];
 MPlayFunc gMPlayJumpTable[36];
 struct CgbChannel gCgbChans[4];
+ALIGNED(4) static char SoundMainRAM_Buffer[0x800] = {0};
 
 #ifdef USE_SDL
 static void SdlAudioCallback(void *userdata, Uint8 *stream, int len)


### PR DESCRIPTION
## Summary
- mark SoundInfo and MusicPlayerInfo ident fields volatile to avoid caching during lock operations
- provide SoundMainRAM buffer in PC build for m4a init

## Testing
- `make pc` *(fails: size of array 'SaveBlock1FreeSpace' is negative in src/save.c)*

------
https://chatgpt.com/codex/tasks/task_e_68bbe65aaee883298b0805c8048780e7