### PR TITLE
Add SDL-backed I/O layer for PC build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -225,8 +225,8 @@ OBJS_REL := $(patsubst $(OBJ_DIR)/%,%,$(OBJS))
 # Objects for the desktop PC build. Use the host compiler and include the
 # emulator BIOS and I/O stubs. Remove objects that rely on the GBA CPU.
 PC_OBJ_DIR := $(BUILD_DIR)/pc
-PC_OBJS := $(addprefix $(PC_OBJ_DIR)/,$(filter-out src/crt0.o src/libgcnmultiboot.o src/m4a_1.o src/rom_header.o src/librfu_intr.o src/multiboot.o,$(OBJS_REL)))
-PC_OBJS += $(PC_OBJ_DIR)/src/pc_bios.o $(PC_OBJ_DIR)/src/pc_io_reg.o $(PC_OBJ_DIR)/src/pc_main.o
+PC_OBJS := $(addprefix $(PC_OBJ_DIR)/,$(filter-out src/crt0.o src/libgcnmultiboot.o src/m4a_1.o src/rom_header.o src/librfu_intr.o src/multiboot.o src/platform/io_stub.o,$(OBJS_REL)))
+PC_OBJS += $(PC_OBJ_DIR)/src/pc_bios.o $(PC_OBJ_DIR)/src/pc_main.o
 
 ifeq ($(OS),Windows_NT)
 AUDIO_LIBS := -lole32 -lwinmm $(shell pkg-config --libs sdl2)

--- a/src/platform/io_pc.c
+++ b/src/platform/io_pc.c
@@ -1,0 +1,93 @@
+#include "platform/io.h"
+
+#ifdef PLATFORM_PC
+#include <SDL2/SDL.h>
+#include <stdlib.h>
+#include "gba/io_reg.h"
+
+// Emulated I/O register space. Shared with the macros in io_reg.h.
+u8 gIoRegisters[0x400];
+
+static SDL_Window *sWindow;
+static SDL_Renderer *sRenderer;
+static SDL_Texture *sTexture;
+static u32 sFramebuffer[240 * 160];
+
+static void InitVideo(void)
+{
+    if (sWindow != NULL)
+        return;
+
+    if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_GAMECONTROLLER) != 0)
+        exit(1);
+
+    sWindow = SDL_CreateWindow("pokeemerald", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED,
+                               240, 160, 0);
+    sRenderer = SDL_CreateRenderer(sWindow, -1, SDL_RENDERER_ACCELERATED);
+    sTexture = SDL_CreateTexture(sRenderer, SDL_PIXELFORMAT_ARGB8888,
+                                 SDL_TEXTUREACCESS_STREAMING, 240, 160);
+}
+
+static void PresentFramebuffer(void)
+{
+    if (sWindow == NULL)
+        return;
+
+    SDL_UpdateTexture(sTexture, NULL, sFramebuffer, 240 * sizeof(u32));
+    SDL_RenderClear(sRenderer);
+    SDL_RenderCopy(sRenderer, sTexture, NULL, NULL);
+    SDL_RenderPresent(sRenderer);
+}
+
+static void PollInput(void)
+{
+    SDL_Event e;
+    while (SDL_PollEvent(&e))
+    {
+        if (e.type == SDL_QUIT)
+            exit(0);
+    }
+
+    const Uint8 *keys = SDL_GetKeyboardState(NULL);
+    u16 state = KEYS_MASK;
+
+    if (keys[SDL_SCANCODE_Z])      state &= ~A_BUTTON;
+    if (keys[SDL_SCANCODE_X])      state &= ~B_BUTTON;
+    if (keys[SDL_SCANCODE_BACKSPACE]) state &= ~SELECT_BUTTON;
+    if (keys[SDL_SCANCODE_RETURN]) state &= ~START_BUTTON;
+    if (keys[SDL_SCANCODE_RIGHT])  state &= ~DPAD_RIGHT;
+    if (keys[SDL_SCANCODE_LEFT])   state &= ~DPAD_LEFT;
+    if (keys[SDL_SCANCODE_UP])     state &= ~DPAD_UP;
+    if (keys[SDL_SCANCODE_DOWN])   state &= ~DPAD_DOWN;
+    if (keys[SDL_SCANCODE_S])      state &= ~R_BUTTON;
+    if (keys[SDL_SCANCODE_A])      state &= ~L_BUTTON;
+
+    *(u16 *)(gIoRegisters + REG_OFFSET_KEYINPUT) = state;
+}
+
+u16 PlatformReadReg(u16 regOffset)
+{
+    if (regOffset == REG_OFFSET_KEYINPUT)
+        PollInput();
+
+    return *(u16 *)(gIoRegisters + regOffset);
+}
+
+void PlatformWriteReg(u16 regOffset, u16 value)
+{
+    *(u16 *)(gIoRegisters + regOffset) = value;
+
+    switch (regOffset)
+    {
+    case REG_OFFSET_DISPCNT:
+    case REG_OFFSET_BG0CNT:
+    case REG_OFFSET_BG1CNT:
+    case REG_OFFSET_BG2CNT:
+    case REG_OFFSET_BG3CNT:
+        InitVideo();
+        PresentFramebuffer();
+        break;
+    }
+}
+#endif // PLATFORM_PC
+


### PR DESCRIPTION
## Summary
- Provide `src/platform/io_pc.c` with SDL2 input and framebuffer handling for desktop builds
- Wire new I/O file into PC build and omit old stub/pc_io_reg from build

## Testing
- `make pc` *(fails: Package sdl2 not found; map_groups.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bbecff0e108329afcb759578001cee