### PR TITLE
Implement desktop BIOS calls and add tests

### DIFF
--- a/libagbsyscall/libagbsyscall.c
+++ b/libagbsyscall/libagbsyscall.c
@@ -7,7 +7,7 @@
 #endif
 
 // NOTE: These are minimal desktop stubs for GBA BIOS syscalls.
-// TODO: Provide high-level implementations where appropriate.
+// The actual desktop implementations live in src/pc_bios.c.
 
 struct BitUnPackParams; // Forward declaration for BitUnPack parameters.
 
@@ -15,47 +15,47 @@ __attribute__((weak)) void IntrWait(u32 flags, u32 unused)
 {
     (void)flags;
     (void)unused;
-    // TODO: Wait for interrupts or VBlank.
+    // Stub; handled by src/pc_bios.c on desktop builds.
 }
 
 __attribute__((weak)) void RegisterRamReset(u32 resetFlags)
 {
     (void)resetFlags;
-    // TODO: Reset selected RAM regions.
+    // Stub; handled by src/pc_bios.c on desktop builds.
 }
 
 __attribute__((weak)) void SoftReset(u32 resetFlags)
 {
     (void)resetFlags;
-    // TODO: Perform a soft reset.
+    // Stub; handled by src/pc_bios.c on desktop builds.
 }
 
 __attribute__((weak)) void SoftResetRom(void)
 {
-    // TODO: Reset using ROM entry point.
+    // Stub; handled by src/pc_bios.c on desktop builds.
 }
 
 __attribute__((weak)) void SoftResetExram(void)
 {
-    // TODO: Reset external RAM.
+    // Stub; handled by src/pc_bios.c on desktop builds.
 }
 
 __attribute__((weak)) void VBlankIntrWait(void)
 {
-    // TODO: Block until VBlank on desktop build.
+    // Stub; handled by src/pc_bios.c on desktop builds.
 }
 
 __attribute__((weak)) u16 Sqrt(u32 num)
 {
     (void)num;
-    // TODO: Implement square root.
+    // Stub; handled by src/pc_bios.c on desktop builds.
     return 0;
 }
 
 __attribute__((weak)) u16 ArcTan(s16 x)
 {
     (void)x;
-    // TODO: Implement arctangent lookup.
+    // Stub; handled by src/pc_bios.c on desktop builds.
     return 0;
 }
 
@@ -63,7 +63,7 @@ __attribute__((weak)) u16 ArcTan2(s16 x, s16 y)
 {
     (void)x;
     (void)y;
-    // TODO: Implement two-argument arctangent.
+    // Stub; handled by src/pc_bios.c on desktop builds.
     return 0;
 }
 
@@ -71,7 +71,7 @@ __attribute__((weak)) s32 Div(s32 num, s32 denom)
 {
     (void)num;
     (void)denom;
-    // TODO: Provide signed division.
+    // Stub; handled by src/pc_bios.c on desktop builds.
     return 0;
 }
 
@@ -79,7 +79,7 @@ __attribute__((weak)) s32 DivArm(s32 num, s32 denom)
 {
     (void)num;
     (void)denom;
-    // TODO: Provide signed division.
+    // Stub; handled by src/pc_bios.c on desktop builds.
     return 0;
 }
 
@@ -87,7 +87,7 @@ __attribute__((weak)) s32 Mod(s32 num, s32 denom)
 {
     (void)num;
     (void)denom;
-    // TODO: Provide modulo operation.
+    // Stub; handled by src/pc_bios.c on desktop builds.
     return 0;
 }
 
@@ -95,7 +95,7 @@ __attribute__((weak)) s32 ModArm(s32 num, s32 denom)
 {
     (void)num;
     (void)denom;
-    // TODO: Provide modulo operation.
+    // Stub; handled by src/pc_bios.c on desktop builds.
     return 0;
 }
 
@@ -104,7 +104,7 @@ __attribute__((weak)) void CpuSet(const void *src, void *dest, u32 control)
     (void)src;
     (void)dest;
     (void)control;
-    // TODO: Implement CpuSet memory copy.
+    // Stub; handled by src/pc_bios.c on desktop builds.
 }
 
 __attribute__((weak)) void CpuFastSet(const void *src, void *dest, u32 control)
@@ -112,7 +112,7 @@ __attribute__((weak)) void CpuFastSet(const void *src, void *dest, u32 control)
     (void)src;
     (void)dest;
     (void)control;
-    // TODO: Implement fast memory copy.
+    // Stub; handled by src/pc_bios.c on desktop builds.
 }
 
 __attribute__((weak)) void BgAffineSet(struct BgAffineSrcData *src, struct BgAffineDstData *dest, s32 count)
@@ -120,7 +120,7 @@ __attribute__((weak)) void BgAffineSet(struct BgAffineSrcData *src, struct BgAff
     (void)src;
     (void)dest;
     (void)count;
-    // TODO: Implement BG affine transformation setup.
+    // Stub; handled by src/pc_bios.c on desktop builds.
 }
 
 __attribute__((weak)) void ObjAffineSet(struct ObjAffineSrcData *src, void *dest, s32 count, s32 offset)
@@ -129,42 +129,42 @@ __attribute__((weak)) void ObjAffineSet(struct ObjAffineSrcData *src, void *dest
     (void)dest;
     (void)count;
     (void)offset;
-    // TODO: Implement OBJ affine transformation setup.
+    // Stub; handled by src/pc_bios.c on desktop builds.
 }
 
 __attribute__((weak)) void LZ77UnCompWram(const u32 *src, void *dest)
 {
     (void)src;
     (void)dest;
-    // TODO: Implement LZ77 decompression to WRAM.
+    // Stub; handled by src/pc_bios.c on desktop builds.
 }
 
 __attribute__((weak)) void LZ77UnCompVram(const u32 *src, void *dest)
 {
     (void)src;
     (void)dest;
-    // TODO: Implement LZ77 decompression to VRAM.
+    // Stub; handled by src/pc_bios.c on desktop builds.
 }
 
 __attribute__((weak)) void RLUnCompWram(const u32 *src, void *dest)
 {
     (void)src;
     (void)dest;
-    // TODO: Implement RLE decompression to WRAM.
+    // Stub; handled by src/pc_bios.c on desktop builds.
 }
 
 __attribute__((weak)) void RLUnCompVram(const u32 *src, void *dest)
 {
     (void)src;
     (void)dest;
-    // TODO: Implement RLE decompression to VRAM.
+    // Stub; handled by src/pc_bios.c on desktop builds.
 }
 
 __attribute__((weak)) void HuffUnComp(const u8 *src, void *dest)
 {
     (void)src;
     (void)dest;
-    // TODO: Implement Huffman decompression.
+    // Not implemented on desktop builds.
 }
 
 __attribute__((weak)) void BitUnPack(const void *src, void *dest, const struct BitUnPackParams *params)
@@ -172,34 +172,34 @@ __attribute__((weak)) void BitUnPack(const void *src, void *dest, const struct B
     (void)src;
     (void)dest;
     (void)params;
-    // TODO: Implement bit unpacking.
+    // Not implemented on desktop builds.
 }
 
 __attribute__((weak)) void Diff8bitUnFilterWram(const void *src, void *dest)
 {
     (void)src;
     (void)dest;
-    // TODO: Implement 8-bit differential unfilter for WRAM.
+    // Not implemented on desktop builds.
 }
 
 __attribute__((weak)) void Diff8bitUnFilterVram(const void *src, void *dest)
 {
     (void)src;
     (void)dest;
-    // TODO: Implement 8-bit differential unfilter for VRAM.
+    // Not implemented on desktop builds.
 }
 
 __attribute__((weak)) void Diff16bitUnFilter(const void *src, void *dest)
 {
     (void)src;
     (void)dest;
-    // TODO: Implement 16-bit differential unfilter.
+    // Not implemented on desktop builds.
 }
 
 __attribute__((weak)) int MultiBoot(struct MultiBootParam *mp)
 {
     (void)mp;
-    // TODO: Implement multi-boot communication.
+    // Stub; handled by src/pc_bios.c on desktop builds.
     return 0;
 }
 
@@ -208,7 +208,7 @@ __attribute__((weak)) u32 MidiKey2Freq(u8 key, u8 fractional, u8 octave)
     (void)key;
     (void)fractional;
     (void)octave;
-    // TODO: Convert MIDI key to frequency.
+    // Stub; handled by src/pc_bios.c on desktop builds.
     return 0;
 }
 
@@ -273,32 +273,32 @@ void SoundBiasChange(void)
 
 __attribute__((weak)) void MusicPlayerOpen(void)
 {
-    // TODO: Open music player.
+    // Not implemented on desktop builds.
 }
 
 __attribute__((weak)) void MusicPlayerStart(void)
 {
-    // TODO: Start playback on music player.
+    // Not implemented on desktop builds.
 }
 
 __attribute__((weak)) void MusicPlayerStop(void)
 {
-    // TODO: Stop playback on music player.
+    // Not implemented on desktop builds.
 }
 
 __attribute__((weak)) void MusicPlayerContinue(void)
 {
-    // TODO: Resume playback on music player.
+    // Not implemented on desktop builds.
 }
 
 __attribute__((weak)) void MusicPlayerFadeOut(void)
 {
-    // TODO: Fade out music player.
+    // Not implemented on desktop builds.
 }
 
 __attribute__((weak)) void SoundChannelClear(void)
 {
-    // TODO: Clear sound channels.
+    // Not implemented on desktop builds.
 }
 
 #endif // GBA

--- a/src/pc_bios.c
+++ b/src/pc_bios.c
@@ -8,9 +8,9 @@
 #include <unistd.h>
 #include "m4a.h"
 
-// Simple stubs for GBA BIOS calls when running on a desktop PC.
-// These provide minimal behaviour sufficient for bringing up the engine
-// without relying on actual GBA hardware or the BIOS.
+// Desktop implementations of a subset of the GBA BIOS calls. These aim to
+// emulate the behaviour of the real BIOS closely enough for engine bring-up
+// and unit testing on a PC.
 
 void SoftReset(u32 resetFlags)
 {
@@ -19,6 +19,16 @@ void SoftReset(u32 resetFlags)
     // the process. The launcher or invoking script is expected to
     // restart the program if desired.
     exit(0);
+}
+
+void SoftResetRom(void)
+{
+    SoftReset(RESET_ALL);
+}
+
+void SoftResetExram(void)
+{
+    SoftReset(RESET_ALL);
 }
 
 void RegisterRamReset(u32 resetFlags)
@@ -66,33 +76,76 @@ u16 ArcTan2(s16 x, s16 y)
 
 void CpuSet(const void *src, void *dest, u32 control)
 {
-    // The real BIOS call supports various modes via the control
-    // parameter. For desktop builds we only need basic copying, so we
-    // ignore the flags and simply perform a memmove.
-    size_t size = control & 0x1FFFFF; // lower 21 bits encode length
-    memmove(dest, src, size);
+    u32 count = control & 0x001FFFFF;
+    bool32 use32 = control & CPU_SET_32BIT;
+    bool32 fixed = control & CPU_SET_SRC_FIXED;
+
+    if (use32)
+    {
+        const u32 *s = src;
+        u32 *d = dest;
+        u32 value = *s;
+        for (u32 i = 0; i < count; i++)
+            d[i] = fixed ? value : s[i];
+    }
+    else
+    {
+        const u16 *s = src;
+        u16 *d = dest;
+        u16 value = *s;
+        for (u32 i = 0; i < count; i++)
+            d[i] = fixed ? value : s[i];
+    }
 }
 
 void CpuFastSet(const void *src, void *dest, u32 control)
 {
-    // Like CpuSet, this simplified implementation just performs a
-    // regular memory move. The "fast" behaviour is irrelevant on
-    // modern CPUs.
-    size_t size = control & 0x1FFFFF;
-    memmove(dest, src, size);
+    u32 count = control & 0x001FFFFF;
+    bool32 fixed = control & CPU_FAST_SET_SRC_FIXED;
+    const u32 *s = src;
+    u32 *d = dest;
+    u32 value = *s;
+
+    // CpuFastSet operates in units of 8 words.
+    for (u32 i = 0; i < count * 8; i++)
+        d[i] = fixed ? value : s[i];
 }
 
 void BgAffineSet(struct BgAffineSrcData *src, struct BgAffineDstData *dest, s32 count)
 {
-    memcpy(dest, src, count * sizeof(*src));
+    for (s32 i = 0; i < count; i++)
+    {
+        double sx = (double)src[i].sx / 256.0;
+        double sy = (double)src[i].sy / 256.0;
+        double angle = src[i].alpha * M_PI / 32768.0;
+        double cosA = cos(angle);
+        double sinA = sin(angle);
+
+        dest[i].pa = (s16)(cosA * sx * 256);
+        dest[i].pb = (s16)(-sinA * sx * 256);
+        dest[i].pc = (s16)(sinA * sy * 256);
+        dest[i].pd = (s16)(cosA * sy * 256);
+
+        dest[i].dx = src[i].texX - ((dest[i].pa * src[i].scrX + dest[i].pb * src[i].scrY) >> 8);
+        dest[i].dy = src[i].texY - ((dest[i].pc * src[i].scrX + dest[i].pd * src[i].scrY) >> 8);
+    }
 }
 
 void ObjAffineSet(struct ObjAffineSrcData *src, void *dest, s32 count, s32 offset)
 {
-    u8 *d = dest;
+    s16 (*d)[4] = dest;
     for (s32 i = 0; i < count; i++)
     {
-        memcpy(d + i * offset, &src[i], sizeof(*src));
+        double x = (double)src[i].xScale / 256.0;
+        double y = (double)src[i].yScale / 256.0;
+        double angle = src[i].rotation * M_PI / 32768.0;
+        double cosA = cos(angle);
+        double sinA = sin(angle);
+
+        d[i * offset / sizeof(*d)][0] = (s16)(cosA * x * 256);
+        d[i * offset / sizeof(*d)][1] = (s16)(-sinA * x * 256);
+        d[i * offset / sizeof(*d)][2] = (s16)(sinA * y * 256);
+        d[i * offset / sizeof(*d)][3] = (s16)(cosA * y * 256);
     }
 }
 
@@ -198,6 +251,23 @@ s32 Mod(s32 num, s32 denom)
     if (denom == 0)
         return 0;
     return num % denom;
+}
+
+s32 DivArm(s32 num, s32 denom)
+{
+    return Div(num, denom);
+}
+
+s32 ModArm(s32 num, s32 denom)
+{
+    return Mod(num, denom);
+}
+
+u32 MidiKey2Freq(u8 key, u8 fractional, u8 octave)
+{
+    double semitone = key + fractional / 256.0 + octave * 12;
+    double freq = 440.0 * pow(2.0, (semitone - 69) / 12.0);
+    return (u32)freq;
 }
 
 #else

--- a/tests/pc_bios_tests.c
+++ b/tests/pc_bios_tests.c
@@ -1,0 +1,49 @@
+#include "gba/types.h"
+#include "gba/syscall.h"
+#include <assert.h>
+#include <string.h>
+#include <stdio.h>
+
+void m4aSoundInit(void) {}
+void m4aSoundMain(void) {}
+void m4aSoundVSync(void) {}
+void m4aSoundVSyncOff(void) {}
+void m4aSoundVSyncOn(void) {}
+void m4aSoundMode(u32 mode) { (void)mode; }
+
+int main(void)
+{
+    // CpuSet 16-bit copy
+    u16 src16[4] = {1, 2, 3, 4};
+    u16 dest16[4] = {0};
+    CpuSet(src16, dest16, 4);
+    assert(memcmp(src16, dest16, sizeof(src16)) == 0);
+
+    // CpuSet 32-bit fill
+    u32 value = 0xDEADBEEF;
+    u32 dest32[4] = {0};
+    CpuSet(&value, dest32, CPU_SET_SRC_FIXED | CPU_SET_32BIT | 4);
+    for (int i = 0; i < 4; i++)
+        assert(dest32[i] == value);
+
+    // BgAffineSet identity
+    struct BgAffineSrcData src = {0, 0, 0, 0, 256, 256, 0};
+    struct BgAffineDstData dst;
+    BgAffineSet(&src, &dst, 1);
+    assert(dst.pa == 256 && dst.pb == 0 && dst.pc == 0 && dst.pd == 256);
+
+    // LZ77 decompression
+    const unsigned char lzData[] = {0x10,0x04,0x00,0x00,0x00,0x41,0x42,0x43,0x44};
+    unsigned char lzOut[4] = {0};
+    LZ77UnCompWram((const u32*)lzData, lzOut);
+    assert(memcmp(lzOut, "ABCD", 4) == 0);
+
+    // RL decompression
+    const unsigned char rlData[] = {0x30,0x08,0x00,0x00,0x81,0x41,0x81,0x42};
+    unsigned char rlOut[8] = {0};
+    RLUnCompWram((const u32*)rlData, rlOut);
+    assert(memcmp(rlOut, "AAAABBBB", 8) == 0);
+
+    printf("All tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- mark BIOS stubs as delegating to pc_bios implementations
- implement CPU copy modes, affine transforms, division helpers, and MIDI frequency conversion for desktop builds
- add unit tests covering memory copies, affine setup, and decompression

## Testing
- `gcc -Iinclude -DPLATFORM_PC tests/pc_bios_tests.c src/pc_bios.c -lm -o tests/pc_bios_tests && ./tests/pc_bios_tests`


------
https://chatgpt.com/codex/tasks/task_e_68bbef3d1040832988971e999d8d1d91