### PR TITLE
Add PC audio reset test

### DIFF
--- a/tests/pc_audio_tests.c
+++ b/tests/pc_audio_tests.c
@@ -1,0 +1,17 @@
+#include "gba/gba.h"
+#include <assert.h>
+#include <stdio.h>
+
+static int sSoundInitCalls;
+void m4aSoundInit(void)
+{
+    sSoundInitCalls++;
+}
+
+int main(void)
+{
+    RegisterRamReset(RESET_SOUND_REGS);
+    assert(sSoundInitCalls == 1);
+    printf("PC audio reset calls m4aSoundInit\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add test ensuring RegisterRamReset triggers m4aSoundInit on PC builds

## Testing
- `gcc -DMODERN=0 -DPLATFORM_PC -iquote include tests/pc_audio_tests.c src/pc_bios.c -lm -o tests/pc_audio_tests`
- `./tests/pc_audio_tests`

------
https://chatgpt.com/codex/tasks/task_e_68bbf25ad90883299e317aa1c3e5acdb