### PR TITLE
Add SDL renderer and VBlank-driven framebuffer updates

### DIFF
--- a/src/platform/io_pc.c
+++ b/src/platform/io_pc.c
@@ -7,6 +7,7 @@
 #include <string.h>
 #include <stdint.h>
 #include "gba/io_reg.h"
+#include "gba/defines.h"
 
 // Emulated I/O register space. Shared with the macros in io_reg.h.
 u8 gIoRegisters[0x400];
@@ -30,6 +31,9 @@ static SDL_Window *sWindow;
 static SDL_Renderer *sRenderer;
 static SDL_Texture *sTexture;
 static u32 sFramebuffer[240 * 160];
+static bool sShowSpriteBoxes;
+
+static void Render(void);
 
 static void InitVideo(void)
 {
@@ -60,11 +64,17 @@ static void PresentFramebuffer(void)
 
 static void PollInput(void)
 {
+    InitVideo();
     SDL_Event e;
     while (SDL_PollEvent(&e))
     {
         if (e.type == SDL_QUIT)
             exit(0);
+        if (e.type == SDL_KEYDOWN)
+        {
+            if (e.key.keysym.sym == SDLK_F1)
+                sShowSpriteBoxes = !sShowSpriteBoxes;
+        }
     }
 
     const Uint8 *keys = SDL_GetKeyboardState(NULL);
@@ -84,14 +94,240 @@ static void PollInput(void)
     *(u16 *)(gIoRegisters + REG_OFFSET_KEYINPUT) = state;
 }
 
+static inline u32 PlttColorToArgb(u16 color)
+{
+    u32 r = (color & 0x1F) << 3;
+    u32 g = ((color >> 5) & 0x1F) << 3;
+    u32 b = ((color >> 10) & 0x1F) << 3;
+    // Replicate high bits for smoother colors
+    r |= r >> 5;
+    g |= g >> 5;
+    b |= b >> 5;
+    return 0xFF000000 | (r << 16) | (g << 8) | b;
+}
+
+static void GetSpriteSize(int shape, int size, int *width, int *height)
+{
+    static const int dimensions[3][4][2] = {
+        {{8,8}, {16,16}, {32,32}, {64,64}},       // square
+        {{16,8}, {32,8}, {32,16}, {64,32}},       // horizontal
+        {{8,16}, {8,32}, {16,32}, {32,64}},       // vertical
+    };
+
+    if (shape > 2 || size > 3)
+    {
+        *width = *height = 8;
+        return;
+    }
+    *width = dimensions[shape][size][0];
+    *height = dimensions[shape][size][1];
+}
+
+static void DrawRect(int x, int y, int w, int h, u32 color)
+{
+    int x2 = x + w - 1;
+    int y2 = y + h - 1;
+    if (x2 < 0 || y2 < 0 || x >= 240 || y >= 160)
+        return;
+    if (x < 0) x = 0;
+    if (y < 0) y = 0;
+    if (x2 >= 240) x2 = 239;
+    if (y2 >= 160) y2 = 159;
+
+    for (int i = x; i <= x2; i++)
+    {
+        sFramebuffer[y * 240 + i] = color;
+        sFramebuffer[y2 * 240 + i] = color;
+    }
+    for (int j = y; j <= y2; j++)
+    {
+        sFramebuffer[j * 240 + x] = color;
+        sFramebuffer[j * 240 + x2] = color;
+    }
+}
+
+static void Render(void)
+{
+    u16 dispcnt = *(u16 *)(gIoRegisters + REG_OFFSET_DISPCNT);
+    u16 *bgPltt = (u16 *)gPCPltt;
+    u16 *objPltt = (u16 *)(gPCPltt + BG_PLTT_SIZE);
+    static u8 sPriorityBuf[240 * 160];
+
+    u32 backdrop = PlttColorToArgb(bgPltt[0]);
+    for (int i = 0; i < 240 * 160; i++)
+    {
+        sFramebuffer[i] = backdrop;
+        sPriorityBuf[i] = 4;
+    }
+
+    if (dispcnt & DISPCNT_FORCED_BLANK)
+        return;
+
+    // Render backgrounds by priority (3 -> 0)
+    for (int prio = 3; prio >= 0; prio--)
+    {
+        for (int bg = 0; bg < 4; bg++)
+        {
+            if (!(dispcnt & (DISPCNT_BG0_ON << bg)))
+                continue;
+
+            u16 bgcnt = *(u16 *)(gIoRegisters + REG_OFFSET_BG0CNT + bg * 2);
+            if ((bgcnt & 3) != prio)
+                continue;
+
+            bool is8bpp = bgcnt & BGCNT_256COLOR;
+            u8 *charBase = BG_CHAR_ADDR((bgcnt >> 2) & 3);
+            u8 *screenBase = BG_SCREEN_ADDR((bgcnt >> 8) & 31);
+            int screenSize = (bgcnt >> 14) & 3;
+            static const int sBgDimensions[4][2] = {{256,256},{512,256},{256,512},{512,512}};
+            int width = sBgDimensions[screenSize][0];
+            int height = sBgDimensions[screenSize][1];
+            u16 hofs = *(u16 *)(gIoRegisters + REG_OFFSET_BG0HOFS + bg * 8);
+            u16 vofs = *(u16 *)(gIoRegisters + REG_OFFSET_BG0VOFS + bg * 8);
+            int tileSize = is8bpp ? 64 : 32;
+
+            for (int y = 0; y < 160; y++)
+            {
+                int yCoord = (y + vofs) % height;
+                int tileRow = yCoord / 8;
+                int inTileY = yCoord % 8;
+                for (int x = 0; x < 240; x++)
+                {
+                    int xCoord = (x + hofs) % width;
+                    int tileCol = xCoord / 8;
+                    int inTileX = xCoord % 8;
+                    u32 block = 0;
+                    switch (screenSize)
+                    {
+                    default:
+                    case 0: block = 0; break;
+                    case 1: block = (tileCol / 32); break; // 512x256
+                    case 2: block = (tileRow / 32); break; // 256x512
+                    case 3: block = (tileRow / 32) * 2 + (tileCol / 32); break; // 512x512
+                    }
+                    u16 *map = (u16 *)(screenBase + block * 0x800);
+                    u16 entry = map[(tileRow % 32) * 32 + (tileCol % 32)];
+                    u16 tileNum = entry & 0x3FF;
+                    bool hflip = entry & 0x400;
+                    bool vflip = entry & 0x800;
+                    u8 palBank = entry >> 12;
+                    u8 *tile = charBase + tileNum * tileSize;
+                    int tx = hflip ? (7 - inTileX) : inTileX;
+                    int ty = vflip ? (7 - inTileY) : inTileY;
+                    u16 colorIndex;
+                    if (is8bpp)
+                    {
+                        colorIndex = tile[ty * 8 + tx];
+                    }
+                    else
+                    {
+                        u8 byte = tile[ty * 4 + tx / 2];
+                        colorIndex = (tx & 1) ? (byte >> 4) : (byte & 0xF);
+                        colorIndex += palBank * 16;
+                    }
+                    u16 color = bgPltt[colorIndex];
+                    int idx = y * 240 + x;
+                    sFramebuffer[idx] = PlttColorToArgb(color);
+                    sPriorityBuf[idx] = prio;
+                }
+            }
+        }
+    }
+
+    // Render sprites
+    if (dispcnt & DISPCNT_OBJ_ON)
+    {
+        bool obj1D = dispcnt & DISPCNT_OBJ_1D_MAP;
+        u16 *oam = (u16 *)gPCOam;
+        for (int i = 0; i < 128; i++)
+        {
+            u16 attr0 = oam[i * 4 + 0];
+            u16 attr1 = oam[i * 4 + 1];
+            u16 attr2 = oam[i * 4 + 2];
+            if (((attr0 >> 8) & 3) == 2) // hidden
+                continue;
+
+            int y = attr0 & 0xFF;
+            int x = attr1 & 0x1FF;
+            if (y >= 160) y -= 256;
+            if (x >= 240) x -= 512;
+
+            int shape = (attr0 >> 14) & 3;
+            int size = (attr1 >> 14) & 3;
+            int width, height;
+            GetSpriteSize(shape, size, &width, &height);
+
+            bool hflip = attr1 & (1 << 12);
+            bool vflip = attr1 & (1 << 13);
+            bool is8bpp = attr0 & (1 << 13);
+            int tileNum = attr2 & 0x3FF;
+            int priority = (attr2 >> 10) & 3;
+            int palNum = (attr2 >> 12) & 0xF;
+            int tileSizeSprite = is8bpp ? 64 : 32;
+            int tilesPerRow = is8bpp ? width / 8 : width / 8;
+
+            for (int py = 0; py < height; py++)
+            {
+                int screenY = y + py;
+                if (screenY < 0 || screenY >= 160)
+                    continue;
+                int ty = vflip ? (height - 1 - py) : py;
+                int tileRow = ty / 8;
+                int inTileY = ty % 8;
+                for (int px = 0; px < width; px++)
+                {
+                    int screenX = x + px;
+                    if (screenX < 0 || screenX >= 240)
+                        continue;
+                    int tx = hflip ? (width - 1 - px) : px;
+                    int tileCol = tx / 8;
+                    int inTileX = tx % 8;
+                    int tileIndex;
+                    if (obj1D)
+                        tileIndex = tileNum + tileRow * tilesPerRow + tileCol;
+                    else
+                        tileIndex = tileNum + tileCol + tileRow * 32;
+                    u8 *tile = OBJ_VRAM0 + tileIndex * tileSizeSprite;
+                    u16 colorIndex;
+                    if (is8bpp)
+                    {
+                        colorIndex = tile[inTileY * 8 + inTileX];
+                        if (colorIndex == 0)
+                            continue;
+                    }
+                    else
+                    {
+                        u8 byte = tile[inTileY * 4 + inTileX / 2];
+                        colorIndex = (inTileX & 1) ? (byte >> 4) : (byte & 0xF);
+                        if (colorIndex == 0)
+                            continue;
+                        colorIndex += palNum * 16;
+                    }
+                    int idx = screenY * 240 + screenX;
+                    if (sPriorityBuf[idx] <= priority)
+                        continue;
+                    u16 color = objPltt[colorIndex];
+                    sFramebuffer[idx] = PlttColorToArgb(color);
+                    sPriorityBuf[idx] = priority;
+                }
+            }
+
+            if (sShowSpriteBoxes)
+                DrawRect(x, y, width, height, 0xFFFF00FF);
+        }
+    }
+}
+
 static void TriggerFramebufferUpdate(void)
 {
     InitVideo();
+    Render();
     PresentFramebuffer();
 }
 
 static void UpdateDisplayState(void)
 {
+    PollInput();
     Uint64 now = SDL_GetPerformanceCounter();
     Uint64 freq = SDL_GetPerformanceFrequency();
 
@@ -114,8 +350,12 @@ static void UpdateDisplayState(void)
         dispstat |= DISPSTAT_VCOUNT;
     *(u16 *)(gIoRegisters + REG_OFFSET_DISPSTAT) = dispstat;
 
-    if ((dispstat & DISPSTAT_VBLANK) && !(prev & DISPSTAT_VBLANK) && (dispstat & DISPSTAT_VBLANK_INTR))
-        *(u16 *)(gIoRegisters + REG_OFFSET_IF) |= INTR_FLAG_VBLANK;
+    if ((dispstat & DISPSTAT_VBLANK) && !(prev & DISPSTAT_VBLANK))
+    {
+        if (dispstat & DISPSTAT_VBLANK_INTR)
+            *(u16 *)(gIoRegisters + REG_OFFSET_IF) |= INTR_FLAG_VBLANK;
+        TriggerFramebufferUpdate();
+    }
     if ((dispstat & DISPSTAT_VCOUNT) && !(prev & DISPSTAT_VCOUNT) && (dispstat & DISPSTAT_VCOUNT_INTR))
         *(u16 *)(gIoRegisters + REG_OFFSET_IF) |= INTR_FLAG_VCOUNT;
 


### PR DESCRIPTION
## Summary
- Render backgrounds and sprites from VRAM, palette and OAM into SDL framebuffer
- Update framebuffer each VBlank and allow toggling sprite bounds with F1

## Testing
- `gcc tests/pc_bios_tests.c src/pc_bios.c -Iinclude -DPLATFORM_PC -DPC -include include/gba/types.h -lm -o pc_bios_tests && ./pc_bios_tests`
- `gcc tests/pc_audio_tests.c src/pc_bios.c -Iinclude -DPLATFORM_PC -DPC -include include/gba/types.h -lm -o pc_audio_tests && ./pc_audio_tests`


------
https://chatgpt.com/codex/tasks/task_e_68bbfb036894832995da11e2e4130586