### PR TITLE
Improve PC flash emulation and tests

### DIFF
--- a/include/agb_flash.h
+++ b/include/agb_flash.h
@@ -11,4 +11,8 @@ u16 SetFlashTimerIntr(u8 timerNum, void (**intrFunc)(void));
 u16 IdentifyFlash(void);
 u32 ProgramFlashSectorAndVerify(u16 sectorNum, u8 *src);
 
+#ifdef PLATFORM_PC
+void SetFlashFilePath(const char *path);
+#endif
+
 #endif //GUARD_AGB_FLASH_H

--- a/tests/pc_flash_tests.c
+++ b/tests/pc_flash_tests.c
@@ -1,0 +1,36 @@
+#include "gba/gba.h"
+#include "save.h"
+#include "gba/flash_internal.h"
+#include "agb_flash.h"
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+int main(void)
+{
+    const char *path = "test_flash.sav";
+    SetFlashFilePath(path);
+    remove(path);
+
+    IdentifyFlash();
+
+    unsigned char writeBuf[SECTOR_SIZE];
+    for (unsigned i = 0; i < SECTOR_SIZE; i++)
+        writeBuf[i] = (unsigned char)i;
+
+    assert(ProgramFlashSectorAndVerify(0, writeBuf) == 0);
+
+    unsigned char readBuf[SECTOR_SIZE];
+    memset(readBuf, 0, sizeof(readBuf));
+    ReadFlash(0, 0, readBuf, SECTOR_SIZE);
+    assert(memcmp(writeBuf, readBuf, SECTOR_SIZE) == 0);
+
+    IdentifyFlash();
+    memset(readBuf, 0, sizeof(readBuf));
+    ReadFlash(0, 0, readBuf, SECTOR_SIZE);
+    assert(memcmp(writeBuf, readBuf, SECTOR_SIZE) == 0);
+
+    remove(path);
+    printf("Flash read/write tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add configurable PC flash save path and file error handling
- enforce sector bounds and wear-level counter in PC flash
- add persistence tests for PC flash emulation

## Testing
- `gcc -Wall -Werror -Iinclude -DPLATFORM_PC tests/pc_flash_tests.c src/pc_flash.c -o tests/pc_flash_tests`
- `./tests/pc_flash_tests`
- `gcc -Wall -Werror -Iinclude -DPLATFORM_PC tests/pc_audio_tests.c src/pc_bios.c -lm -o tests/pc_audio_tests`
- `./tests/pc_audio_tests`
- `gcc -Wall -Iinclude -DPLATFORM_PC tests/pc_bios_tests.c src/pc_bios.c -lm -o tests/pc_bios_tests`
- `./tests/pc_bios_tests`


------
https://chatgpt.com/codex/tasks/task_e_68bc004ca29c83298f3071b5e6b465a5