### PR TITLE
Use SDL audio subsystem

### DIFF
--- a/libagbsyscall/libagbsyscall.c
+++ b/libagbsyscall/libagbsyscall.c
@@ -214,46 +214,32 @@ __attribute__((weak)) u32 MidiKey2Freq(u8 key, u8 fractional, u8 octave)
 
 void SoundDriverInit(void)
 {
-#ifdef PLATFORM_PC
     m4aSoundInit();
-#endif
 }
 
 void SoundDriverMain(void)
 {
-#ifdef PLATFORM_PC
     m4aSoundMain();
-#endif
 }
 
 void SoundDriverVSync(void)
 {
-#ifdef PLATFORM_PC
     m4aSoundVSync();
-#endif
 }
 
 void SoundDriverVSyncOff(void)
 {
-#ifdef PLATFORM_PC
     m4aSoundVSyncOff();
-#endif
 }
 
 void SoundDriverVSyncOn(void)
 {
-#ifdef PLATFORM_PC
     m4aSoundVSyncOn();
-#endif
 }
 
 void SoundDriverMode(u32 mode)
 {
-#ifdef PLATFORM_PC
     m4aSoundMode(mode);
-#else
-    (void)mode;
-#endif
 }
 
 void SoundBiasSet(void)

--- a/src/pc_audio.c
+++ b/src/pc_audio.c
@@ -93,7 +93,7 @@ static void m4aSoundShutdown(void)
     {
         SDL_CloseAudioDevice(sAudioDevice);
         sAudioDevice = 0;
-        SDL_Quit();
+        SDL_QuitSubSystem(SDL_INIT_AUDIO);
     }
 }
 #endif // USE_SDL


### PR DESCRIPTION
## Summary
- ensure SDL audio subsystem shuts down cleanly
- forward sound driver wrappers directly to m4a SDL backend

## Testing
- `gcc -Iinclude -DPLATFORM_PC tests/pc_audio_tests.c src/pc_bios.c -lm -o tests/pc_audio_tests && ./tests/pc_audio_tests`
- `gcc -Iinclude -DPLATFORM_PC tests/pc_bios_tests.c src/pc_bios.c src/pc_flash.c -lm -o tests/pc_bios_tests && ./tests/pc_bios_tests`
- `gcc -Iinclude -DPLATFORM_PC tests/pc_flash_tests.c src/pc_flash.c src/pc_bios.c /tmp/m4a_stub.c -lm -o tests/pc_flash_tests && ./tests/pc_flash_tests`
- `gcc -Iinclude -DPLATFORM_PC tests/pc_audio_tests.c src/pc_bios.c libagbsyscall/libagbsyscall.c /tmp/m4a_stub_noinit.c -lm -o tests/pc_audio_tests_wrappers && ./tests/pc_audio_tests_wrappers`


------
https://chatgpt.com/codex/tasks/task_e_68bc04a678e0832988d0036adf2aeb5c