### PR TITLE
Route GBA register access through PC buffer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -226,7 +226,7 @@ OBJS_REL := $(patsubst $(OBJ_DIR)/%,%,$(OBJS))
 # emulator BIOS and I/O stubs. Remove objects that rely on the GBA CPU.
 PC_OBJ_DIR := $(BUILD_DIR)/pc
 PC_OBJS := $(addprefix $(PC_OBJ_DIR)/,$(filter-out src/crt0.o src/libgcnmultiboot.o src/m4a.o src/m4a_1.o src/rom_header.o src/librfu_intr.o src/multiboot.o src/platform/io_stub.o src/pc_audio.o src/platform/io_pc.o,$(OBJS_REL)))
-PC_OBJS += $(PC_OBJ_DIR)/src/pc_bios.o $(PC_OBJ_DIR)/src/pc_main.o $(PC_OBJ_DIR)/src/pc_audio.o $(PC_OBJ_DIR)/src/platform/io_pc.o
+PC_OBJS += $(PC_OBJ_DIR)/src/pc_bios.o $(PC_OBJ_DIR)/src/pc_main.o $(PC_OBJ_DIR)/src/pc_audio.o $(PC_OBJ_DIR)/src/platform/io_pc.o $(PC_OBJ_DIR)/src/pc_io_reg.o
 
 ifeq ($(OS),Windows_NT)
 AUDIO_LIBS := -lole32 -lwinmm $(shell pkg-config --libs sdl2)

--- a/include/gba/io_reg.h
+++ b/include/gba/io_reg.h
@@ -349,6 +349,8 @@
 
 #ifdef PLATFORM_PC
 extern u8 gIoRegisters[0x400];
+#undef REG_BASE
+#define REG_BASE gIoRegisters
 #define REG_IO_U8(offset)  (*(volatile u8  *)(gIoRegisters + (offset)))
 #define REG_IO_U16(offset) (*(volatile u16 *)(gIoRegisters + (offset)))
 #define REG_IO_U32(offset) (*(volatile u32 *)(gIoRegisters + (offset)))

--- a/src/battle_dome.c
+++ b/src/battle_dome.c
@@ -5682,9 +5682,9 @@ static void VblankCb_TourneyInfoCard(void)
     TransferPlttBuffer();
 }
 
-#define SET_WIN0H_WIN1H(win0H, win1H)                       \
-{                                                           \
-    *(vu32*)(REG_ADDR_WIN0H) = ((win0H << 16) | (win1H));   \
+#define SET_WIN0H_WIN1H(win0H, win1H)                                       \
+{                                                                           \
+    WRITE_REG_U32(REG_OFFSET_WIN0H, ((win0H << 16) | (win1H)));             \
 }
 
 static void HblankCb_TourneyTree(void)

--- a/src/dma3_manager.c
+++ b/src/dma3_manager.c
@@ -55,7 +55,7 @@ void ProcessDma3Requests(void)
 
         if (bytesTransferred > 40 * 1024)
             return; // don't transfer more than 40 KiB
-        if (*(u8 *)REG_ADDR_VCOUNT > 224)
+        if (READ_REG_U8(REG_OFFSET_VCOUNT) > 224)
             return; // we're about to leave vblank, stop
 
         switch (sDma3Requests[sDma3RequestCursor].mode)

--- a/src/ereader_helpers.c
+++ b/src/ereader_helpers.c
@@ -705,7 +705,7 @@ int EReaderHandleTransfer(u8 mode, size_t size, const void *data, void *recvBuff
 static u16 DetermineSendRecvState(u8 mode)
 {
     bool16 resp;
-    if ((*(vu32 *)REG_ADDR_SIOCNT & (SIO_MULTI_SI | SIO_MULTI_SD)) == SIO_MULTI_SD && mode)
+    if ((READ_REG_U32(REG_OFFSET_SIOCNT) & (SIO_MULTI_SI | SIO_MULTI_SD)) == SIO_MULTI_SD && mode)
         resp = sSendRecvMgr.isParent = TRUE;
     else
         resp = sSendRecvMgr.isParent = FALSE;

--- a/src/link.c
+++ b/src/link.c
@@ -1989,7 +1989,7 @@ static void CheckMasterOrSlave(void)
 {
     u32 terminals;
 
-    terminals = *(vu32 *)REG_ADDR_SIOCNT & (SIO_MULTI_SD | SIO_MULTI_SI);
+    terminals = READ_REG_U32(REG_OFFSET_SIOCNT) & (SIO_MULTI_SD | SIO_MULTI_SI);
     if (terminals == SIO_MULTI_SD && gLink.localId == 0)
     {
         gLink.isMaster = LINK_MASTER;

--- a/src/m4a.c
+++ b/src/m4a.c
@@ -421,10 +421,10 @@ void SampleFreqSet(u32 freq)
 
     m4aSoundVSyncOn();
 
-    while (*(vu8 *)REG_ADDR_VCOUNT == 159)
+    while (READ_REG_U8(REG_OFFSET_VCOUNT) == 159)
         ;
 
-    while (*(vu8 *)REG_ADDR_VCOUNT != 159)
+    while (READ_REG_U8(REG_OFFSET_VCOUNT) != 159)
         ;
 
     REG_TM0CNT_H = TIMER_ENABLE | TIMER_1CLK;


### PR DESCRIPTION
## Summary
- Map GBA IO register macros to an emulated `gIoRegisters` buffer for PC builds
- Compile `pc_io_reg.c` and route platform I/O via READ/WRITE register helpers
- Replace direct register writes with READ_REG_*/WRITE_REG_* macros across engine and macros

## Testing
- `make pc` *(fails: map_groups.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bc0e7f2fc4832982127eb17e038109