### PR TITLE
Compile PC BIOS on x86 and expose BIOS stubs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -226,7 +226,7 @@ OBJS_REL := $(patsubst $(OBJ_DIR)/%,%,$(OBJS))
 # emulator BIOS and I/O stubs. Remove objects that rely on the GBA CPU.
 PC_OBJ_DIR := $(BUILD_DIR)/pc
 PC_OBJS := $(addprefix $(PC_OBJ_DIR)/,$(filter-out src/crt0.o src/libgcnmultiboot.o src/m4a.o src/m4a_1.o src/rom_header.o src/librfu_intr.o src/multiboot.o src/platform/io_stub.o src/pc_audio.o src/platform/io_pc.o,$(OBJS_REL)))
-PC_OBJS += $(PC_OBJ_DIR)/src/pc_bios.o $(PC_OBJ_DIR)/src/pc_main.o $(PC_OBJ_DIR)/src/pc_audio.o $(PC_OBJ_DIR)/src/platform/io_pc.o $(PC_OBJ_DIR)/src/pc_io_reg.o
+PC_OBJS += $(PC_OBJ_DIR)/src/pc_bios.o $(PC_OBJ_DIR)/src/pc_main.o $(PC_OBJ_DIR)/src/pc_audio.o $(PC_OBJ_DIR)/src/platform/io_pc.o $(PC_OBJ_DIR)/src/pc_io_reg.o $(PC_OBJ_DIR)/libagbsyscall/libagbsyscall.o
 
 ifeq ($(OS),Windows_NT)
 AUDIO_LIBS := -lole32 -lwinmm $(shell pkg-config --libs sdl2)

--- a/include/gba/syscall.h
+++ b/include/gba/syscall.h
@@ -12,13 +12,17 @@
 #define RESET_ALL        0xFF
 
 void SoftReset(u32 resetFlags);
+void SoftResetRom(void);
+void SoftResetExram(void);
 
 void RegisterRamReset(u32 resetFlags);
 
+void IntrWait(u32 flags, u32 unused);
 void VBlankIntrWait(void);
 
 u16 Sqrt(u32 num);
 
+u16 ArcTan(s16 x);
 u16 ArcTan2(s16 x, s16 y);
 
 #define CPU_SET_SRC_FIXED 0x01000000
@@ -65,8 +69,29 @@ void RLUnCompWram(const u32 *src, void *dest);
 
 void RLUnCompVram(const u32 *src, void *dest);
 
+void HuffUnComp(const u8 *src, void *dest);
+
+struct BitUnPackParams
+{
+    u16 srcLength;
+    u8 srcBitNum;
+    u8 destBitNum;
+    u32 destOffset:31;
+    u32 offset0On:1;
+};
+void BitUnPack(const void *src, void *dest, const struct BitUnPackParams *params);
+
+void Diff8bitUnFilterWram(const void *src, void *dest);
+void Diff8bitUnFilterVram(const void *src, void *dest);
+void Diff16bitUnFilter(const void *src, void *dest);
+
 int MultiBoot(struct MultiBootParam *mp);
 
 s32 Div(s32 num, s32 denom);
+s32 Mod(s32 num, s32 denom);
+s32 DivArm(s32 num, s32 denom);
+s32 ModArm(s32 num, s32 denom);
+
+u32 MidiKey2Freq(u8 key, u8 fractional, u8 octave);
 
 #endif // GUARD_GBA_SYSCALL_H


### PR DESCRIPTION
## Summary
- Compile `pc_bios.c` and `libagbsyscall.c` in desktop builds so BIOS and sound driver stubs link on x86.
- Expose additional BIOS function prototypes to map gameplay calls to desktop implementations.

## Testing
- `make build/pc/src/pc_bios.o`
- `make build/pc/libagbsyscall/libagbsyscall.o`


------
https://chatgpt.com/codex/tasks/task_e_68bc11175fbc8329bcc4ef00da16b712