### PR TITLE
Define PC macro and allocate buffers in pc_main

### DIFF
--- a/include/platform.h
+++ b/include/platform.h
@@ -5,6 +5,7 @@
 // This allows code to provide alternate implementations without breaking
 // the original hardware build.
 #ifdef PLATFORM_PC
+#define PC
 #define PLATFORM_GBA 0
 #else
 #define PLATFORM_GBA 1

--- a/src/main.c
+++ b/src/main.c
@@ -25,9 +25,6 @@
 #include "main.h"
 #include "trainer_hill.h"
 #include "constants/rgb.h"
-#ifdef PC
-#include <stdlib.h>
-#endif
 
 static void VBlankIntr(void);
 static void HBlankIntr(void);
@@ -103,11 +100,6 @@ void AgbMain(void)
 #if !MODERN
     RegisterRamReset(RESET_ALL);
 #endif //MODERN
-#ifdef PC
-    gPCVram = malloc(VRAM_SIZE);
-    gPCPltt = malloc(PLTT_SIZE);
-    gPCOam = malloc(OAM_SIZE);
-#endif
     *(vu16 *)BG_PLTT = RGB_WHITE; // Set the backdrop to white on startup
     InitGpuRegManager();
     PlatformWriteReg(REG_OFFSET_WAITCNT, WAITCNT_PREFETCH_ENABLE | WAITCNT_WS0_S_1 | WAITCNT_WS0_N_3);

--- a/src/pc_main.c
+++ b/src/pc_main.c
@@ -1,9 +1,14 @@
 #include "global.h"
 #include "main.h"
+#include <stdlib.h>
 
 #ifdef PC
 int main(void)
 {
+    gPCVram = malloc(VRAM_SIZE);
+    gPCPltt = malloc(PLTT_SIZE);
+    gPCOam = malloc(OAM_SIZE);
+
     AgbMain();
     return 0;
 }


### PR DESCRIPTION
## Summary
- Define `PC` whenever `PLATFORM_PC` is set
- Allocate VRAM/PLTT/OAM buffers in `main` before initializing the engine
- Start the game loop by calling `AgbMain()` from `main`

## Testing
- `make -j2` *(fails: tools/agbcc/bin/agbcc missing, string.h not found)*
- `make pc -j2` *(fails: static declaration of `lman` conflicts with extern)*

------
https://chatgpt.com/codex/tasks/task_e_68bc133fbcc48329a8ebfd4a999a125f