### PR TITLE
Enable SDL audio for PC builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,7 @@ endif
 # Collect sources
 C_SRCS_IN := $(wildcard $(C_SUBDIR)/*.c $(C_SUBDIR)/*/*.c $(C_SUBDIR)/*/*/*.c)
 C_SRCS := $(foreach src,$(C_SRCS_IN),$(if $(findstring .inc.c,$(src)),,$(src)))
-C_SRCS := $(filter-out $(C_SUBDIR)/pc_bios.c $(C_SUBDIR)/pc_io_reg.c $(C_SUBDIR)/pc_main.c,$(C_SRCS))
+C_SRCS := $(filter-out $(C_SUBDIR)/pc_bios.c $(C_SUBDIR)/pc_io_reg.c $(C_SUBDIR)/pc_main.c $(C_SUBDIR)/pc_audio.c,$(C_SRCS))
 C_OBJS := $(patsubst $(C_SUBDIR)/%.c,$(C_BUILDDIR)/%.o,$(C_SRCS))
 
 C_ASM_SRCS := $(wildcard $(C_SUBDIR)/*.s $(C_SUBDIR)/*/*.s $(C_SUBDIR)/*/*/*.s)
@@ -225,7 +225,7 @@ OBJS_REL := $(patsubst $(OBJ_DIR)/%,%,$(OBJS))
 # Objects for the desktop PC build. Use the host compiler and include the
 # emulator BIOS and I/O stubs. Remove objects that rely on the GBA CPU.
 PC_OBJ_DIR := $(BUILD_DIR)/pc
-PC_OBJS := $(addprefix $(PC_OBJ_DIR)/,$(filter-out src/crt0.o src/libgcnmultiboot.o src/m4a.o src/m4a_1.o src/rom_header.o src/librfu_intr.o src/multiboot.o src/platform/io_stub.o src/pc_audio.o src/platform/io_pc.o,$(OBJS_REL)))
+PC_OBJS := $(addprefix $(PC_OBJ_DIR)/,$(filter-out src/crt0.o src/libgcnmultiboot.o src/m4a.o src/m4a_1.o src/rom_header.o src/librfu_intr.o src/multiboot.o src/platform/io_stub.o src/platform/io_pc.o,$(OBJS_REL)))
 PC_OBJS += $(PC_OBJ_DIR)/src/pc_bios.o $(PC_OBJ_DIR)/src/pc_main.o $(PC_OBJ_DIR)/src/pc_audio.o $(PC_OBJ_DIR)/src/platform/io_pc.o $(PC_OBJ_DIR)/src/pc_io_reg.o $(PC_OBJ_DIR)/libagbsyscall/libagbsyscall.o
 
 ifeq ($(OS),Windows_NT)

--- a/include/m4a.h
+++ b/include/m4a.h
@@ -8,6 +8,9 @@ void m4aSoundVSyncOn(void);
 
 void m4aSoundInit(void);
 void m4aSoundMain(void);
+#if PLATFORM_PC
+void m4aSoundShutdown(void);
+#endif
 void m4aSongNumStart(u16 n);
 void m4aSongNumStartOrChange(u16 n);
 void m4aSongNumStop(u16 n);

--- a/src/pc_audio.c
+++ b/src/pc_audio.c
@@ -87,7 +87,7 @@ static void SdlAudioCallback(void *userdata, Uint8 *stream, int len)
     }
 }
 
-static void m4aSoundShutdown(void)
+void m4aSoundShutdown(void)
 {
     if (sAudioDevice != 0)
     {
@@ -373,7 +373,6 @@ void m4aSoundInit(void)
     }
 
     SDL_PauseAudioDevice(sAudioDevice, 0);
-    atexit(m4aSoundShutdown);
 #endif
 }
 

--- a/src/pc_main.c
+++ b/src/pc_main.c
@@ -1,10 +1,12 @@
 #include "global.h"
 #include "main.h"
+#include "m4a.h"
 #include <stdlib.h>
 
 #ifdef PC
 int main(void)
 {
+    atexit(m4aSoundShutdown);
     gPCVram = malloc(VRAM_SIZE);
     gPCPltt = malloc(PLTT_SIZE);
     gPCOam = malloc(OAM_SIZE);


### PR DESCRIPTION
## Summary
- build PC binaries with `src/pc_audio.c`
- initialize SDL audio via `m4aSoundInit` and expose a shutdown helper
- close the SDL audio device at exit for clean shutdown

## Testing
- `gcc -Wall tests/pc_audio_tests.c src/pc_bios.c -I include -lm -DPLATFORM_PC -o pc_audio_tests` *(fails: redefinition of struct BitUnPackParams)*

------
https://chatgpt.com/codex/tasks/task_e_68bc14fb61e48329a29eda5c821149f7