### PR TITLE
Ensure PC audio shutdown

### DIFF
--- a/src/pc_audio.c
+++ b/src/pc_audio.c
@@ -87,16 +87,20 @@ static void SdlAudioCallback(void *userdata, Uint8 *stream, int len)
     }
 }
 
+
+#endif // USE_SDL
+
 void m4aSoundShutdown(void)
 {
+#ifdef USE_SDL
     if (sAudioDevice != 0)
     {
         SDL_CloseAudioDevice(sAudioDevice);
         sAudioDevice = 0;
         SDL_QuitSubSystem(SDL_INIT_AUDIO);
     }
+#endif
 }
-#endif // USE_SDL
 
 u32 MidiKeyToFreq(struct WaveData *wav, u8 key, u8 fineAdjust)
 {


### PR DESCRIPTION
## Summary
- Run SDL audio callback through SoundMain and expose a shutdown routine for device cleanup.

## Testing
- `gcc tests/pc_audio_tests.c src/pc_bios.c src/pc_audio.c -Iinclude -DPLATFORM_PC -DPC 2>&1 | tail -n 20` *(fails: map_groups.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bc26bb217c832997ed1b61209c18b2