### PR TITLE
Link RTC to host system time

### DIFF
--- a/src/pc_flash.c
+++ b/src/pc_flash.c
@@ -9,6 +9,10 @@
 #include <stdio.h>
 #include <string.h>
 
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
+
 static char sSaveFilePath[PATH_MAX] = "pokeemerald.sav";
 
 static u8 sFlashMemory[SECTORS_COUNT * SECTOR_SIZE];

--- a/tests/pc_rtc_tests.c
+++ b/tests/pc_rtc_tests.c
@@ -1,0 +1,32 @@
+#include "siirtc.h"
+#include <assert.h>
+#include <stdio.h>
+#include <time.h>
+#include <stdlib.h>
+
+static int bcd_to_binary(int bcd)
+{
+    return ((bcd >> 4) & 0xF) * 10 + (bcd & 0xF);
+}
+
+int main(void)
+{
+    struct SiiRtcInfo rtc;
+    SiiRtcGetDateTime(&rtc);
+
+    time_t now = time(NULL);
+    struct tm *t = localtime(&now);
+
+    assert(bcd_to_binary(rtc.year) == ((t->tm_year + 1900) % 100));
+    assert(bcd_to_binary(rtc.month) == t->tm_mon + 1);
+    assert(bcd_to_binary(rtc.day) == t->tm_mday);
+    assert(bcd_to_binary(rtc.hour) == t->tm_hour);
+    assert(bcd_to_binary(rtc.minute) == t->tm_min);
+
+    int rtcSec = bcd_to_binary(rtc.second);
+    int sysSec = t->tm_sec;
+    assert(abs(rtcSec - sysSec) <= 1);
+
+    printf("RTC matches system time\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- adapt S-3511A RTC interface to pull from host system clock on Windows, Linux or macOS
- add PC-side test ensuring RTC matches the system clock

## Testing
- `gcc -std=c99 -Iinclude tests/pc_rtc_tests.c src/siirtc.c -o tests/pc_rtc_tests`
- `./tests/pc_rtc_tests`
- `gcc -std=c99 -Iinclude tests/pc_audio_tests.c -o tests/pc_audio_tests` *(fails: undefined reference to `RegisterRamReset`)*
- `gcc -std=c99 -Iinclude tests/pc_bios_tests.c -o tests/pc_bios_tests` *(fails: undefined reference to `CpuSet` etc.)*
- `gcc -std=c99 -Iinclude tests/pc_flash_tests.c -o tests/pc_flash_tests` *(fails: undefined reference to `SetFlashFilePath` etc.)*
- `make -j2` *(fails: arm-none-eabi-as: No such file or directory; missing sdl2)*

------
https://chatgpt.com/codex/tasks/task_e_68bc2a4b1f188329bdb74d734696b79c