### PR TITLE
Expand PC BIOS tests

### DIFF
--- a/tests/pc_bios_tests.c
+++ b/tests/pc_bios_tests.c
@@ -13,6 +13,19 @@ void m4aSoundMode(u32 mode) { (void)mode; }
 
 int main(void)
 {
+    // Sqrt
+    assert(Sqrt(0) == 0);
+    assert(Sqrt(9) == 3);
+    assert(Sqrt(10) == 3);
+
+    // ArcTan
+    assert(ArcTan(0) == 0);
+    assert(ArcTan(256) == 0x2000);
+
+    // ArcTan2
+    assert(ArcTan2(256, 256) == 0x2000);
+    assert(ArcTan2(-256, 256) == 0x6000);
+
     // CpuSet 16-bit copy
     u16 src16[4] = {1, 2, 3, 4};
     u16 dest16[4] = {0};
@@ -26,11 +39,30 @@ int main(void)
     for (int i = 0; i < 4; i++)
         assert(dest32[i] == value);
 
+    // CpuFastSet copy
+    u32 srcFast[8] = {1,2,3,4,5,6,7,8};
+    u32 destFast[8] = {0};
+    CpuFastSet(srcFast, destFast, 1);
+    assert(memcmp(srcFast, destFast, sizeof(srcFast)) == 0);
+
+    // CpuFastSet fill
+    u32 fillVal = 0xDEADBEEF;
+    u32 destFill[8] = {0};
+    CpuFastSet(&fillVal, destFill, CPU_FAST_SET_SRC_FIXED | 1);
+    for (int i = 0; i < 8; i++)
+        assert(destFill[i] == fillVal);
+
     // BgAffineSet identity
     struct BgAffineSrcData src = {0, 0, 0, 0, 256, 256, 0};
     struct BgAffineDstData dst;
     BgAffineSet(&src, &dst, 1);
     assert(dst.pa == 256 && dst.pb == 0 && dst.pc == 0 && dst.pd == 256);
+
+    // ObjAffineSet identity
+    struct ObjAffineSrcData objSrc = {256, 256, 0};
+    s16 objDst[4];
+    ObjAffineSet(&objSrc, objDst, 1, 8);
+    assert(objDst[0] == 256 && objDst[1] == 0 && objDst[2] == 0 && objDst[3] == 256);
 
     // LZ77 decompression
     const unsigned char lzData[] = {0x10,0x04,0x00,0x00,0x00,0x41,0x42,0x43,0x44};


### PR DESCRIPTION
## Summary
- cover Sqrt, ArcTan, and ArcTan2 BIOS calls
- verify CpuFastSet copy and fill modes
- assert ObjAffineSet generates an identity matrix

## Testing
- `gcc -std=c99 tests/pc_audio_tests.c src/pc_bios.c -Iinclude -I. -DPLATFORM_PC -lm -o pc_audio_tests && ./pc_audio_tests`
- `gcc -std=c99 tests/pc_bios_tests.c src/pc_bios.c -Iinclude -I. -DPLATFORM_PC -lm -o pc_bios_tests && ./pc_bios_tests`
- `gcc -std=c99 tests/pc_flash_tests.c src/pc_flash.c -Iinclude -I. -DPLATFORM_PC -lm -o pc_flash_tests && ./pc_flash_tests`
- `gcc -std=c99 tests/pc_rtc_tests.c src/siirtc.c -Iinclude -I. -DPLATFORM_PC -lm -o pc_rtc_tests && ./pc_rtc_tests`


------
https://chatgpt.com/codex/tasks/task_e_68bc2d56b8948329ac43bae22f171775