### PR TITLE
Enable proper scaling on PC window resize

### DIFF
--- a/src/AgbRfu_LinkManager.c
+++ b/src/AgbRfu_LinkManager.c
@@ -14,7 +14,11 @@
 #define FSP_ON    0x01
 #define FSP_START 0x02
 
+#ifdef PC
+LINK_MANAGER lman = {0};
+#else
 COMMON_DATA LINK_MANAGER lman = {0};
+#endif
 
 static void rfu_LMAN_clearVariables(void);
 static void rfu_LMAN_settingPCSWITCH(u32 rand);

--- a/src/platform/io_pc.c
+++ b/src/platform/io_pc.c
@@ -43,8 +43,11 @@ static void InitVideo(void)
         exit(1);
 
     sWindow = SDL_CreateWindow("pokeemerald", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED,
-                               240, 160, 0);
+                               240, 160, SDL_WINDOW_RESIZABLE);
+    SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "nearest");
     sRenderer = SDL_CreateRenderer(sWindow, -1, SDL_RENDERER_ACCELERATED);
+    SDL_RenderSetLogicalSize(sRenderer, 240, 160);
+    SDL_RenderSetIntegerScale(sRenderer, SDL_TRUE);
     sTexture = SDL_CreateTexture(sRenderer, SDL_PIXELFORMAT_ARGB8888,
                                  SDL_TEXTUREACCESS_STREAMING, 240, 160);
 


### PR DESCRIPTION
## Summary
- allow SDL window to be resized and preserve crisp rendering
- use SDL's logical size to scale game display
- fix link manager global data definition for PC builds

## Testing
- `./tests/pc_bios_tests` *(fails: No such file or directory)*
- `./tests/pc_audio_tests` *(fails: No such file or directory)*
- `./tests/pc_flash_tests` *(fails: No such file or directory)*
- `./tests/pc_rtc_tests` *(fails: No such file or directory)*
- `make pc` *(fails: duplicate 'static' in battle_ai_script_commands.c)*

------
https://chatgpt.com/codex/tasks/task_e_68bc310868e48329b6083ef3b0e431a2