### PR TITLE
Use PLATFORM_PC macro for desktop builds

### DIFF
--- a/include/gba/defines.h
+++ b/include/gba/defines.h
@@ -6,7 +6,7 @@
 #define TRUE  1
 #define FALSE 0
 
-#ifdef PC
+#if PLATFORM_PC
 #define IWRAM_DATA static
 #define EWRAM_DATA static
 #define COMMON_DATA static
@@ -35,7 +35,7 @@
 #define IWRAM_START 0x03000000
 #define IWRAM_END   (IWRAM_START + 0x8000)
 
-#ifndef PC
+#if !PLATFORM_PC
 #define PLTT          0x5000000
 #define BG_PLTT       PLTT
 #define BG_PLTT_SIZE  0x200

--- a/include/platform.h
+++ b/include/platform.h
@@ -4,12 +4,10 @@
 // Define PLATFORM_PC for desktop builds. When undefined the build targets the GBA.
 // This allows code to provide alternate implementations without breaking
 // the original hardware build.
-#ifdef PLATFORM_PC
-#define PC
+#if PLATFORM_PC
 #define PLATFORM_GBA 0
 #else
 #define PLATFORM_GBA 1
-#define GBA
 #endif
 
 #endif // GUARD_PLATFORM_H

--- a/include/platform/io.h
+++ b/include/platform/io.h
@@ -5,7 +5,7 @@
 #include "gba/types.h"
 #include "gba/io_reg.h"
 
-#ifdef GBA
+#if PLATFORM_GBA
 static inline u16 PlatformReadReg(u16 regOffset)
 {
     return *(vu16 *)(REG_BASE + regOffset);
@@ -18,6 +18,6 @@ static inline void PlatformWriteReg(u16 regOffset, u16 value)
 #else
 u16 PlatformReadReg(u16 regOffset);
 void PlatformWriteReg(u16 regOffset, u16 value);
-#endif // GBA
+#endif // PLATFORM_GBA
 
 #endif // GUARD_PLATFORM_IO_H

--- a/libagbsyscall/libagbsyscall.c
+++ b/libagbsyscall/libagbsyscall.c
@@ -1,10 +1,8 @@
 #include "gba/gba.h"
 
-#ifndef GBA
+#if PLATFORM_PC
 
-#ifdef PLATFORM_PC
 #include "m4a.h"
-#endif
 
 // Desktop wrappers for BIOS sound driver calls. Other BIOS functions
 // are provided by src/pc_bios.c on non-GBA builds.
@@ -84,5 +82,5 @@ __attribute__((weak)) void SoundChannelClear(void)
     // Not implemented on desktop builds.
 }
 
-#endif // GBA
+#endif // PLATFORM_PC
 

--- a/src/AgbRfu_LinkManager.c
+++ b/src/AgbRfu_LinkManager.c
@@ -14,7 +14,7 @@
 #define FSP_ON    0x01
 #define FSP_START 0x02
 
-#ifdef PC
+#if PLATFORM_PC
 LINK_MANAGER lman = {0};
 #else
 COMMON_DATA LINK_MANAGER lman = {0};

--- a/src/libgcnmultiboot.c
+++ b/src/libgcnmultiboot.c
@@ -1,7 +1,7 @@
 #include "libgcnmultiboot.h"
 #include "gba/gba.h"
 
-#ifndef GBA
+#if PLATFORM_PC
 
 // Desktop stubs for GameCube multiboot routines.
 // TODO: Provide high-level implementation of GameCube link transfers.
@@ -43,4 +43,4 @@ void GameCubeMultiBoot_Quit(void)
     // TODO: Clean up multiboot session and restore state.
 }
 
-#endif // GBA
+#endif // PLATFORM_PC

--- a/src/main.c
+++ b/src/main.c
@@ -70,7 +70,7 @@ COMMON_DATA u8 gLinkVSyncDisabled = 0;
 COMMON_DATA u32 IntrMain_Buffer[0x200] = {0};
 COMMON_DATA s8 gPcmDmaCounter = 0;
 
-#ifdef PC
+#if PLATFORM_PC
 u8 *gPCVram = NULL;
 u8 *gPCPltt = NULL;
 u8 *gPCOam = NULL;

--- a/src/palette.c
+++ b/src/palette.c
@@ -5,7 +5,7 @@
 #include "gpu_regs.h"
 #include "task.h"
 #include "constants/rgb.h"
-#ifdef PC
+#if PLATFORM_PC
 #include <string.h>
 #endif
 
@@ -109,7 +109,7 @@ void TransferPlttBuffer(void)
     {
         void *src = gPlttBufferFaded;
         void *dest = (void *)PLTT;
-#ifdef PC
+#if PLATFORM_PC
         memcpy(dest, src, PLTT_SIZE);
 #else
         DmaCopy16(3, src, dest, PLTT_SIZE);
@@ -153,7 +153,7 @@ void ResetPaletteFade(void)
 static void ReadPlttIntoBuffers(void)
 {
     u16 *pltt = (u16 *)PLTT;
-#ifdef PC
+#if PLATFORM_PC
     memcpy(gPlttBufferUnfaded, pltt, PLTT_SIZE);
     memcpy(gPlttBufferFaded, pltt, PLTT_SIZE);
 #else

--- a/src/pc_main.c
+++ b/src/pc_main.c
@@ -3,7 +3,7 @@
 #include "m4a.h"
 #include <stdlib.h>
 
-#ifdef PC
+#if PLATFORM_PC
 int main(void)
 {
     atexit(m4aSoundShutdown);

--- a/src/platform/io_stub.c
+++ b/src/platform/io_stub.c
@@ -1,6 +1,6 @@
 #include "platform/io.h"
 
-#ifndef GBA
+#if PLATFORM_PC
 #define IO_REG_COUNT 0x400
 static u16 sIoRegs[IO_REG_COUNT / 2];
 
@@ -13,4 +13,4 @@ void PlatformWriteReg(u16 regOffset, u16 value)
 {
     sIoRegs[regOffset / 2] = value;
 }
-#endif // GBA
+#endif // PLATFORM_PC


### PR DESCRIPTION
## Summary
- Replace legacy `PC` guards with `PLATFORM_PC` checks throughout headers and sources
- Drop `PC`/`GBA` macros in favor of `PLATFORM_PC`/`PLATFORM_GBA`
- Keep Makefile's PC rule defining `-DPLATFORM_PC`

## Testing
- `make clean`
- `make pc` *(fails: map_groups.h: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_68bc36a824608329aa87d465bfd4981f