### PR TITLE
Include libgcnmultiboot in PC build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -225,7 +225,7 @@ OBJS_REL := $(patsubst $(OBJ_DIR)/%,%,$(OBJS))
 # Objects for the desktop PC build. Use the host compiler and include the
 # emulator BIOS and I/O stubs. Remove objects that rely on the GBA CPU.
 PC_OBJ_DIR := $(BUILD_DIR)/pc
-PC_OBJS := $(addprefix $(PC_OBJ_DIR)/,$(filter-out src/crt0.o src/libgcnmultiboot.o src/m4a.o src/m4a_1.o src/rom_header.o src/librfu_intr.o src/multiboot.o src/platform/io_stub.o,$(OBJS_REL)))
+PC_OBJS := $(addprefix $(PC_OBJ_DIR)/,$(filter-out src/crt0.o src/m4a.o src/m4a_1.o src/rom_header.o src/librfu_intr.o src/multiboot.o src/platform/io_stub.o,$(OBJS_REL)))
 PC_OBJS += $(PC_OBJ_DIR)/src/platform/io_pc.o
 PC_OBJS += $(PC_OBJ_DIR)/src/pc_bios.o $(PC_OBJ_DIR)/src/pc_main.o $(PC_OBJ_DIR)/src/pc_audio.o $(PC_OBJ_DIR)/src/pc_io_reg.o $(PC_OBJ_DIR)/libagbsyscall/libagbsyscall.o
 


### PR DESCRIPTION
## Summary
- allow libgcnmultiboot to be compiled for the PC target by keeping its object in the build

## Testing
- `make pc` *(fails: `src/battle_ai_script_commands.c:155:1: error: duplicate 'static'`)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3a8fcf048329b36d15b0f98fdaf1