### PR TITLE
Add PC multiboot stubs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,7 @@ endif
 # Collect sources
 C_SRCS_IN := $(wildcard $(C_SUBDIR)/*.c $(C_SUBDIR)/*/*.c $(C_SUBDIR)/*/*/*.c)
 C_SRCS := $(foreach src,$(C_SRCS_IN),$(if $(findstring .inc.c,$(src)),,$(src)))
-C_SRCS := $(filter-out $(C_SUBDIR)/pc_bios.c $(C_SUBDIR)/pc_io_reg.c $(C_SUBDIR)/pc_main.c $(C_SUBDIR)/pc_audio.c,$(C_SRCS))
+C_SRCS := $(filter-out $(C_SUBDIR)/pc_bios.c $(C_SUBDIR)/pc_io_reg.c $(C_SUBDIR)/pc_main.c $(C_SUBDIR)/pc_audio.c $(C_SUBDIR)/pc_multiboot.c,$(C_SRCS))
 C_OBJS := $(patsubst $(C_SUBDIR)/%.c,$(C_BUILDDIR)/%.o,$(C_SRCS))
 
 C_ASM_SRCS := $(wildcard $(C_SUBDIR)/*.s $(C_SUBDIR)/*/*.s $(C_SUBDIR)/*/*/*.s)
@@ -225,9 +225,9 @@ OBJS_REL := $(patsubst $(OBJ_DIR)/%,%,$(OBJS))
 # Objects for the desktop PC build. Use the host compiler and include the
 # emulator BIOS and I/O stubs. Remove objects that rely on the GBA CPU.
 PC_OBJ_DIR := $(BUILD_DIR)/pc
-PC_OBJS := $(addprefix $(PC_OBJ_DIR)/,$(filter-out src/crt0.o src/m4a.o src/m4a_1.o src/rom_header.o src/librfu_intr.o src/multiboot.o src/platform/io_stub.o,$(OBJS_REL)))
+PC_OBJS := $(addprefix $(PC_OBJ_DIR)/,$(filter-out src/crt0.o src/m4a.o src/m4a_1.o src/rom_header.o src/librfu_intr.o src/multiboot.o src/platform/io_stub.o src/pc_multiboot.o,$(OBJS_REL)))
 PC_OBJS += $(PC_OBJ_DIR)/src/platform/io_pc.o
-PC_OBJS += $(PC_OBJ_DIR)/src/pc_bios.o $(PC_OBJ_DIR)/src/pc_main.o $(PC_OBJ_DIR)/src/pc_audio.o $(PC_OBJ_DIR)/src/pc_io_reg.o $(PC_OBJ_DIR)/libagbsyscall/libagbsyscall.o
+PC_OBJS += $(PC_OBJ_DIR)/src/pc_bios.o $(PC_OBJ_DIR)/src/pc_main.o $(PC_OBJ_DIR)/src/pc_audio.o $(PC_OBJ_DIR)/src/pc_io_reg.o $(PC_OBJ_DIR)/src/pc_multiboot.o $(PC_OBJ_DIR)/libagbsyscall/libagbsyscall.o
 
 ifeq ($(OS),Windows_NT)
 AUDIO_LIBS := -lole32 -lwinmm $(shell pkg-config --libs sdl2)

--- a/src/pc_multiboot.c
+++ b/src/pc_multiboot.c
@@ -1,0 +1,43 @@
+#include "global.h"
+#include "multiboot.h"
+#include "gba/multiboot.h"
+
+#if PLATFORM_PC
+#include <string.h>
+
+void MultiBootInit(struct MultiBootParam *mp)
+{
+    if (mp != NULL)
+        memset(mp, 0, sizeof(*mp));
+}
+
+int MultiBootMain(struct MultiBootParam *mp)
+{
+    (void)mp;
+    return 0;
+}
+
+void MultiBootStartProbe(struct MultiBootParam *mp)
+{
+    if (mp != NULL)
+        mp->probe_count = 0;
+}
+
+void MultiBootStartMaster(struct MultiBootParam *mp, const u8 *srcp, int length, u8 palette_color, s8 palette_speed)
+{
+    (void)palette_speed;
+    if (mp != NULL)
+    {
+        mp->boot_srcp = srcp;
+        mp->boot_endp = srcp + length;
+        mp->palette_data = palette_color;
+    }
+}
+
+int MultiBootCheckComplete(struct MultiBootParam *mp)
+{
+    (void)mp;
+    return 1;
+}
+
+#endif // PLATFORM_PC


### PR DESCRIPTION
## Summary
- add PC build stubs for MultiBoot routines
- include pc multiboot source in desktop build

## Testing
- `make generated`
- `make pc` *(fails: duplicate 'static' in battle_ai_script_commands.c)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3bfeb3bc8329ae89778874832cd9