### PR TITLE
Handle null script on PC builds

### DIFF
--- a/src/script.c
+++ b/src/script.c
@@ -102,8 +102,12 @@ bool8 RunScriptCommand(struct ScriptContext *ctx)
 
             if (ctx->scriptPtr == gNullScriptPtr)
             {
+#if PLATFORM_GBA
                 while (1)
                     asm("svc 2"); // HALT
+#else
+                for (;;);
+#endif
             }
 
             cmdCode = *(ctx->scriptPtr);


### PR DESCRIPTION
## Summary
- Guard RunScriptCommand's halt with PLATFORM_GBA and provide an infinite loop fallback for desktop builds

## Testing
- `make pc` (fails: duplicate 'static' in battle_ai_script_commands.c)
- `make build/pc/src/script.o`


------
https://chatgpt.com/codex/tasks/task_e_68bd07cabac88329a1a9767c2c0cecdc