### PR TITLE
Guard GBA assertion traps for PC builds

### DIFF
--- a/src/libisagbprn.c
+++ b/src/libisagbprn.c
@@ -1,5 +1,6 @@
 #include <stdarg.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include "gba/gba.h"
 #include "config.h"
 #include "malloc.h"
@@ -163,7 +164,11 @@ void AGBAssert(const char *pFile, int nLine, const char *pExpression, int nStopP
     {
         AGBPrintf("ASSERTION FAILED  FILE=[%s] LINE=[%d]  EXP=[%s] \n", pFile, nLine, pExpression);
         AGBPrintFlush();
+#if PLATFORM_GBA
         asm(".hword 0xEFFF");
+#else
+        abort();
+#endif
     }
     else
     {
@@ -200,7 +205,11 @@ void NoCashGBAAssert(const char *pFile, s32 nLine, const char *pExpression, bool
     if (nStopProgram)
     {
         NoCashGBAPrintf("ASSERTION FAILED  FILE=[%s] LINE=[%d]  EXP=[%s]", pFile, nLine, pExpression);
+#if PLATFORM_GBA
         asm(".hword 0xEFFF");
+#else
+        abort();
+#endif
     }
     else
     {
@@ -246,7 +255,11 @@ void MgbaAssert(const char *pFile, s32 nLine, const char *pExpression, bool32 nS
     if (nStopProgram)
     {
         MgbaPrintf(MGBA_LOG_ERROR, "ASSERTION FAILED  FILE=[%s] LINE=[%d]  EXP=[%s]", pFile, nLine, pExpression);
+#if PLATFORM_GBA
         asm(".hword 0xEFFF");
+#else
+        abort();
+#endif
     }
     else
     {


### PR DESCRIPTION
## Summary
- Use `#if PLATFORM_GBA` around inline assembly triggers in debug assert helpers
- Provide `abort()` fallbacks so PC debug builds compile
- Include `<stdlib.h>` for abort definition

## Testing
- ⚠️ `make pc` *(fails: Package sdl2 was not found; map_groups.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bd09668110832987be55fdee64153b