### PR TITLE
Allow manual SDL flags when pkg-config absent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -228,11 +228,23 @@ PC_OBJ_DIR := $(BUILD_DIR)/pc
 PC_OBJS := $(addprefix $(PC_OBJ_DIR)/,$(filter-out src/crt0.o src/m4a.o src/m4a_1.o src/rom_header.o src/librfu_intr.o src/multiboot.o src/platform/io_stub.o src/pc_multiboot.o,$(OBJS_REL)))
 PC_OBJS += $(PC_OBJ_DIR)/src/platform/io_pc.o
 PC_OBJS += $(PC_OBJ_DIR)/src/pc_bios.o $(PC_OBJ_DIR)/src/pc_main.o $(PC_OBJ_DIR)/src/pc_audio.o $(PC_OBJ_DIR)/src/pc_io_reg.o $(PC_OBJ_DIR)/src/pc_multiboot.o $(PC_OBJ_DIR)/libagbsyscall/libagbsyscall.o
+PKG_CONFIG := $(shell which pkg-config 2>/dev/null)
+ifeq ($(PKG_CONFIG),)
+  ifeq ($(SDL_CFLAGS),)
+    $(error pkg-config not found; please set SDL_CFLAGS and SDL_LIBS)
+  endif
+  ifeq ($(SDL_LIBS),)
+    $(error pkg-config not found; please set SDL_CFLAGS and SDL_LIBS)
+  endif
+else
+  SDL_CFLAGS ?= $(shell pkg-config --cflags sdl2)
+  SDL_LIBS ?= $(shell pkg-config --libs sdl2)
+endif
 
 ifeq ($(OS),Windows_NT)
-AUDIO_LIBS := -lole32 -lwinmm $(shell pkg-config --libs sdl2)
+AUDIO_LIBS := -lole32 -lwinmm $(SDL_LIBS)
 else
-AUDIO_LIBS := -lpthread -ldl $(shell pkg-config --libs sdl2)
+AUDIO_LIBS := -lpthread -ldl $(SDL_LIBS)
 endif
 
 SUBDIRS  := $(sort $(dir $(OBJS)))
@@ -253,20 +265,20 @@ $(BUILD_DIR)/pc/pokeemerald: $(PC_OBJS)
 $(PC_OBJ_DIR)/%.o: %.c
 	mkdir -p $(dir $@)
 	$(HOSTCC) -DMODERN=$(MODERN) -DPLATFORM_PC -DUSE_SDL -D__INTELLISENSE__ -I include -include gba/types.h \
-	$(shell pkg-config --cflags sdl2) -c $< -o $@
+	$(SDL_CFLAGS) -c $< -o $@
 
 # Convert MIDI files into objects for the PC build.
 $(PC_OBJ_DIR)/sound/songs/midi/%.o: sound/songs/midi/%.mid
 	mkdir -p $(dir $@)
 	$(PREPROC) $< charmap.txt | $(MID) -o $(PC_OBJ_DIR)/sound/songs/midi/$*.s -
 	$(HOSTCC) -DMODERN=$(MODERN) -DPLATFORM_PC -DUSE_SDL -D__INTELLISENSE__ -x assembler-with-cpp -I include \
-	$(shell pkg-config --cflags sdl2) -c $(PC_OBJ_DIR)/sound/songs/midi/$*.s -o $@
+	$(SDL_CFLAGS) -c $(PC_OBJ_DIR)/sound/songs/midi/$*.s -o $@
 
 # Assemble data sources for the PC build.
 $(PC_OBJ_DIR)/%.o: %.s
 	mkdir -p $(dir $@)
 	$(HOSTCC) -DMODERN=$(MODERN) -DPLATFORM_PC -DUSE_SDL -D__INTELLISENSE__ -x assembler-with-cpp -I include \
-	$(shell pkg-config --cflags sdl2) -c $< -o $@
+	$(SDL_CFLAGS) -c $< -o $@
 
 # Other rules
 rom: $(ROM)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,11 @@ It builds the following ROM:
 
 * [**pokeemerald.gba**](https://datomatic.no-intro.org/index.php?page=show_record&s=23&n=1961) `sha1: f3ae088181bf583e55daf962a92bb46f4f1d07b7`
 
-You can also compile a minimal PC build with `make pc`, which uses the host compiler and includes `src/pc_bios.c`. This build outputs audio via SDL2; install SDL2 development libraries before building.
+You can also compile a minimal PC build with `make pc`, which uses the host compiler and includes `src/pc_bios.c`. This build outputs audio via SDL2; install SDL2 development libraries before building. The build system looks for SDL2 using `pkg-config`. If `pkg-config` is unavailable, provide SDL paths manually with the `SDL_CFLAGS` and `SDL_LIBS` variables:
+
+```
+make pc SDL_CFLAGS="-I/opt/SDL2/include" SDL_LIBS="-L/opt/SDL2/lib -lSDL2"
+```
 
 To set up the repository, see [INSTALL.md](INSTALL.md).
 


### PR DESCRIPTION
## Summary
- Detect absence of pkg-config and allow manual SDL_CFLAGS/SDL_LIBS overrides
- Document SDL override variables for PC builds

## Testing
- `make clean`
- `make pc` *(fails: duplicate 'static')*
- `make pc SDL_CFLAGS="$SAVED_SDL_CFLAGS" SDL_LIBS="$SAVED_SDL_LIBS"` *(fails: duplicate 'static')*

------
https://chatgpt.com/codex/tasks/task_e_68bd0a9244c08329ba32e2283dcc1b02