### PR TITLE
Fix libgcnmultiboot compile error by including global header

### DIFF
--- a/src/libgcnmultiboot.c
+++ b/src/libgcnmultiboot.c
@@ -1,5 +1,5 @@
+#include "global.h"
 #include "libgcnmultiboot.h"
-#include "gba/gba.h"
 
 #if PLATFORM_PC
 


### PR DESCRIPTION
## Summary
- include `global.h` before `libgcnmultiboot.h` to ensure types like `u16` are defined

## Testing
- `make -j2` *(fails: arm-none-eabi-as: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bd1e46f9dc83298a07b85a087f89ff