### PR TITLE
Link PC RTC to system clock

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,7 @@ endif
 # Collect sources
 C_SRCS_IN := $(wildcard $(C_SUBDIR)/*.c $(C_SUBDIR)/*/*.c $(C_SUBDIR)/*/*/*.c)
 C_SRCS := $(foreach src,$(C_SRCS_IN),$(if $(findstring .inc.c,$(src)),,$(src)))
-C_SRCS := $(filter-out $(C_SUBDIR)/pc_bios.c $(C_SUBDIR)/pc_io_reg.c $(C_SUBDIR)/pc_main.c $(C_SUBDIR)/pc_audio.c $(C_SUBDIR)/pc_multiboot.c $(C_SUBDIR)/libgcnmultiboot.c,$(C_SRCS))
+C_SRCS := $(filter-out $(C_SUBDIR)/pc_bios.c $(C_SUBDIR)/pc_io_reg.c $(C_SUBDIR)/pc_main.c $(C_SUBDIR)/pc_audio.c $(C_SUBDIR)/pc_multiboot.c $(C_SUBDIR)/pc_rtc.c $(C_SUBDIR)/libgcnmultiboot.c,$(C_SRCS))
 C_OBJS := $(patsubst $(C_SUBDIR)/%.c,$(C_BUILDDIR)/%.o,$(C_SRCS))
 
 C_ASM_SRCS := $(wildcard $(C_SUBDIR)/*.s $(C_SUBDIR)/*/*.s $(C_SUBDIR)/*/*/*.s)
@@ -227,7 +227,7 @@ OBJS_REL := $(patsubst $(OBJ_DIR)/%,%,$(OBJS))
 PC_OBJ_DIR := $(BUILD_DIR)/pc
 PC_OBJS := $(addprefix $(PC_OBJ_DIR)/,$(filter-out src/crt0.o src/m4a.o src/m4a_1.o src/rom_header.o src/librfu_intr.o src/multiboot.o src/platform/io_stub.o src/pc_multiboot.o src/libgcnmultiboot.o,$(OBJS_REL)))
 PC_OBJS += $(PC_OBJ_DIR)/src/platform/io_pc.o
-PC_OBJS += $(PC_OBJ_DIR)/src/pc_bios.o $(PC_OBJ_DIR)/src/pc_main.o $(PC_OBJ_DIR)/src/pc_audio.o $(PC_OBJ_DIR)/src/pc_io_reg.o $(PC_OBJ_DIR)/src/pc_multiboot.o $(PC_OBJ_DIR)/libagbsyscall/libagbsyscall.o
+PC_OBJS += $(PC_OBJ_DIR)/src/pc_bios.o $(PC_OBJ_DIR)/src/pc_main.o $(PC_OBJ_DIR)/src/pc_audio.o $(PC_OBJ_DIR)/src/pc_io_reg.o $(PC_OBJ_DIR)/src/pc_multiboot.o $(PC_OBJ_DIR)/src/pc_rtc.o $(PC_OBJ_DIR)/libagbsyscall/libagbsyscall.o
 PKG_CONFIG := $(shell which pkg-config 2>/dev/null)
 ifeq ($(PKG_CONFIG),)
   ifeq ($(SDL_CFLAGS),)

--- a/src/pc_rtc.c
+++ b/src/pc_rtc.c
@@ -1,0 +1,68 @@
+#include "siirtc.h"
+
+#ifdef PLATFORM_PC
+#include <time.h>
+
+static u8 BinaryToBcd(int value) { return ((value / 10) << 4) | (value % 10); }
+
+void SiiRtcUnprotect(void) {}
+
+void SiiRtcProtect(void) {}
+
+u8 SiiRtcProbe(void) { return 1; }
+
+bool8 SiiRtcReset(void) { return TRUE; }
+
+bool8 SiiRtcGetStatus(struct SiiRtcInfo *rtc) {
+  rtc->status = SIIRTCINFO_24HOUR;
+  return TRUE;
+}
+
+static void ReadSysTime(struct SiiRtcInfo *rtc) {
+  time_t now = time(NULL);
+  struct tm t;
+#if defined(_WIN32)
+  localtime_s(&t, &now);
+#else
+  localtime_r(&now, &t);
+#endif
+  rtc->year = BinaryToBcd((t.tm_year + 1900) % 100);
+  rtc->month = BinaryToBcd(t.tm_mon + 1);
+  rtc->day = BinaryToBcd(t.tm_mday);
+  rtc->dayOfWeek = t.tm_wday;
+  rtc->hour = BinaryToBcd(t.tm_hour);
+  rtc->minute = BinaryToBcd(t.tm_min);
+  rtc->second = BinaryToBcd(t.tm_sec);
+}
+
+bool8 SiiRtcGetDateTime(struct SiiRtcInfo *rtc) {
+  ReadSysTime(rtc);
+  return TRUE;
+}
+
+bool8 SiiRtcSetStatus(struct SiiRtcInfo *rtc) {
+  (void)rtc;
+  return TRUE;
+}
+
+bool8 SiiRtcSetDateTime(struct SiiRtcInfo *rtc) {
+  (void)rtc;
+  return TRUE;
+}
+
+bool8 SiiRtcGetTime(struct SiiRtcInfo *rtc) {
+  ReadSysTime(rtc);
+  return TRUE;
+}
+
+bool8 SiiRtcSetTime(struct SiiRtcInfo *rtc) {
+  (void)rtc;
+  return TRUE;
+}
+
+bool8 SiiRtcSetAlarm(struct SiiRtcInfo *rtc) {
+  (void)rtc;
+  return TRUE;
+}
+
+#endif // PLATFORM_PC


### PR DESCRIPTION
## Summary
- Link RTC on desktop builds to system time
- Include pc_rtc in PC build pipeline

## Testing
- `gcc -DPLATFORM_PC -I include -include gba/types.h tests/pc_rtc_tests.c src/pc_rtc.c -o tests/pc_rtc_tests && ./tests/pc_rtc_tests`
- `make -j2 PLATFORM_PC=1` *(fails: tools/agbcc/bin/agbcc: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bd2f6630b883299171f58d55f99ca3