### PR TITLE
Avoid static redefinition for PC builds

### DIFF
--- a/include/gba/defines.h
+++ b/include/gba/defines.h
@@ -7,9 +7,9 @@
 #define FALSE 0
 
 #if PLATFORM_PC
-#define IWRAM_DATA static
-#define EWRAM_DATA static
-#define COMMON_DATA static
+#define IWRAM_DATA
+#define EWRAM_DATA
+#define COMMON_DATA
 #define UNUSED __attribute__((unused))
 #else
 #define IWRAM_DATA __attribute__((section("iwram_data")))


### PR DESCRIPTION
## Summary
- Fix EWRAM/IWRAM/COMMON macros on PC builds so they no longer expand to `static`
- Prevents duplicate `static` qualifiers that caused compilation failure

## Testing
- `make pc` *(fails: build terminated after partial compile due to missing SDL2, but `battle_ai_script_commands.c` builds without errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bd3f08cac88329baf395db0e31392f