### PR TITLE
Fix pointer-size casts and VRAM offset in menu.c for PC build

### DIFF
--- a/src/menu.c
+++ b/src/menu.c
@@ -1911,7 +1911,13 @@ void BgDmaFill(u32 bg, u8 value, int offset, int size)
 {
     int temp = (!GetBgAttribute(bg, BG_ATTR_PALETTEMODE)) ? 32 : 64;
     u32 addr = (GetBgAttribute(bg, BG_ATTR_CHARBASEINDEX) * 0x4000) + (GetBgAttribute(bg, BG_ATTR_BASETILE) + offset) * temp;
-    RequestDma3Fill(value << 24 | value << 16 | value << 8 | value, VRAM + addr, size * temp, 1);
+    RequestDma3Fill(value << 24 | value << 16 | value << 8 | value,
+#if PLATFORM_PC
+                    VRAM + addr,
+#else
+                    (void *)(VRAM + addr),
+#endif
+                    size * temp, 1);
 }
 
 void AddTextPrinterParameterized3(u8 windowId, u8 fontId, u8 left, u8 top, const u8 *color, s8 speed, const u8 *str)

--- a/src/menu.c
+++ b/src/menu.c
@@ -1805,7 +1805,7 @@ void DecompressAndLoadBgGfxUsingHeap(u8 bgId, const void *src, u32 size, u16 off
     {
         u8 taskId = CreateTask(task_free_buf_after_copying_tile_data_to_vram, 0);
         gTasks[taskId].data[0] = copy_decompressed_tile_data_to_vram(bgId, ptr, size, offset, mode);
-        SetWordTaskArg(taskId, 1, (u32)ptr);
+        SetWordTaskArg(taskId, 1, (uintptr_t)ptr);
     }
 }
 
@@ -1813,7 +1813,7 @@ void task_free_buf_after_copying_tile_data_to_vram(u8 taskId)
 {
     if (!CheckForSpaceForDma3Request(gTasks[taskId].data[0]))
     {
-        Free((void *)GetWordTaskArg(taskId, 1));
+        Free((void *)(uintptr_t)GetWordTaskArg(taskId, 1));
         DestroyTask(taskId);
     }
 }
@@ -1910,7 +1910,7 @@ void ResetBgPositions(void)
 void BgDmaFill(u32 bg, u8 value, int offset, int size)
 {
     int temp = (!GetBgAttribute(bg, BG_ATTR_PALETTEMODE)) ? 32 : 64;
-    void *addr = (void *)((GetBgAttribute(bg, BG_ATTR_CHARBASEINDEX) * 0x4000) + (GetBgAttribute(bg, BG_ATTR_BASETILE) + offset) * temp);
+    u32 addr = (GetBgAttribute(bg, BG_ATTR_CHARBASEINDEX) * 0x4000) + (GetBgAttribute(bg, BG_ATTR_BASETILE) + offset) * temp;
     RequestDma3Fill(value << 24 | value << 16 | value << 8 | value, VRAM + addr, size * temp, 1);
 }
 


### PR DESCRIPTION
## Summary
- Safely store pointers in tasks using `uintptr_t`
- Correct VRAM offset calculation to avoid invalid pointer arithmetic

## Testing
- `make` *(fails: build halted after toolchain steps; no error in relevant code)*
- `make pc` *(fails: missing SDL2 and map groups headers)*

------
https://chatgpt.com/codex/tasks/task_e_68bd41747a048329be6d3c1583a7a51c