### PR TITLE
Fix structure sizes for PC build

### DIFF
--- a/include/global.berry.h
+++ b/include/global.berry.h
@@ -72,6 +72,6 @@ struct BerryTree
     u8 watered2:1;
     u8 watered3:1;
     u8 watered4:1;
-};
+} __attribute__((aligned(4)));
 
 #endif // GUARD_GLOBAL_BERRY_H

--- a/include/global.fieldmap.h
+++ b/include/global.fieldmap.h
@@ -95,7 +95,11 @@ struct ObjectEventTemplate
              //u16 padding2:8;
     /*0x0C*/ u16 trainerType;
     /*0x0E*/ u16 trainerRange_berryTreeId;
+#if defined(PLATFORM_PC)
+    /*0x10*/ u32 script; // Pointer stored as 32-bit on PC builds
+#else
     /*0x10*/ const u8 *script;
+#endif
     /*0x14*/ u16 flagId;
     /*0x16*/ //u8 padding3[2];
 };

--- a/include/global.h
+++ b/include/global.h
@@ -603,7 +603,7 @@ struct Pokeblock
     u8 bitter;
     u8 sour;
     u8 feel;
-};
+} __attribute__((aligned(4)));
 
 struct Roamer
 {

--- a/src/event_object_movement.c
+++ b/src/event_object_movement.c
@@ -2372,7 +2372,12 @@ void SetObjectEventDirection(struct ObjectEvent *objectEvent, u8 direction)
 
 static const u8 *GetObjectEventScriptPointerByLocalIdAndMap(u8 localId, u8 mapNum, u8 mapGroup)
 {
-    return GetObjectEventTemplateByLocalIdAndMap(localId, mapNum, mapGroup)->script;
+    const struct ObjectEventTemplate *template = GetObjectEventTemplateByLocalIdAndMap(localId, mapNum, mapGroup);
+#ifdef PLATFORM_PC
+    return (const u8 *)(uintptr_t)template->script;
+#else
+    return template->script;
+#endif
 }
 
 const u8 *GetObjectEventScriptPointerByObjectEventId(u8 objectEventId)
@@ -2493,7 +2498,13 @@ static void OverrideObjectEventTemplateScript(const struct ObjectEvent *objectEv
 
     objectEventTemplate = GetBaseTemplateForObjectEvent(objectEvent);
     if (objectEventTemplate)
+    {
+#ifdef PLATFORM_PC
+        objectEventTemplate->script = (u32)(uintptr_t)script;
+#else
         objectEventTemplate->script = script;
+#endif
+    }
 }
 
 void TryOverrideTemplateCoordsForObjectEvent(const struct ObjectEvent *objectEvent, u8 movementType)

--- a/src/overworld.c
+++ b/src/overworld.c
@@ -484,7 +484,13 @@ void LoadSaveblockObjEventScripts(void)
     s32 i;
 
     for (i = 0; i < OBJECT_EVENT_TEMPLATES_COUNT; i++)
+    {
+#ifdef PLATFORM_PC
+        savObjTemplates[i].script = (u32)(uintptr_t)mapHeaderObjTemplates[i].script;
+#else
         savObjTemplates[i].script = mapHeaderObjTemplates[i].script;
+#endif
+    }
 }
 
 void SetObjEventTemplateCoords(u8 localId, s16 x, s16 y)


### PR DESCRIPTION
## Summary
- align Pokeblock and BerryTree structs to match GBA layout
- store object event script pointers as 32-bit values on PC
- cast script pointers when reading or writing object event templates

## Testing
- `make pc -j2` *(fails: initializer element is not constant in src/tileset_anims.c)*

------
https://chatgpt.com/codex/tasks/task_e_68bd4620f294832998aa4405b6ebbbd8