### PR TITLE
Fix PC assembly preprocessing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -271,14 +271,18 @@ $(PC_OBJ_DIR)/%.o: %.c
 $(PC_OBJ_DIR)/sound/songs/midi/%.o: sound/songs/midi/%.mid
 	mkdir -p $(dir $@)
 	$(PREPROC) $< charmap.txt | $(MID) -o $(PC_OBJ_DIR)/sound/songs/midi/$*.s -
-	$(HOSTCC) -DMODERN=$(MODERN) -DPLATFORM_PC -DUSE_SDL -D__INTELLISENSE__ -x assembler-with-cpp -I include \
-	$(SDL_CFLAGS) -c $(PC_OBJ_DIR)/sound/songs/midi/$*.s -o $@
+	$(PREPROC) $(PC_OBJ_DIR)/sound/songs/midi/$*.s charmap.txt | \
+	$(CPP) $(INCLUDE_SCANINC_ARGS) -DMODERN=$(MODERN) -DPLATFORM_PC -DUSE_SDL -D__INTELLISENSE__ $(SDL_CFLAGS) - | \
+	$(PREPROC) -ie $(PC_OBJ_DIR)/sound/songs/midi/$*.s charmap.txt | \
+	$(HOSTCC) -c -x assembler -o $@ -
 
 # Assemble data sources for the PC build.
 $(PC_OBJ_DIR)/%.o: %.s
 	mkdir -p $(dir $@)
-	$(HOSTCC) -DMODERN=$(MODERN) -DPLATFORM_PC -DUSE_SDL -D__INTELLISENSE__ -x assembler-with-cpp -I include \
-	$(SDL_CFLAGS) -c $< -o $@
+	$(PREPROC) $< charmap.txt | \
+	$(CPP) $(INCLUDE_SCANINC_ARGS) -DMODERN=$(MODERN) -DPLATFORM_PC -DUSE_SDL -D__INTELLISENSE__ $(SDL_CFLAGS) - | \
+	$(PREPROC) -ie $< charmap.txt | \
+	$(HOSTCC) -c -x assembler -o $@ -
 
 # Other rules
 rom: $(ROM)


### PR DESCRIPTION
## Summary
- Preprocess assembly sources in the PC build with preproc and cpp so ARM-style comments and enums are handled correctly
- Apply the same preprocessing when converting MIDI files to object files for the PC build

## Testing
- `make generated`
- `make pc` *(fails: Failed to open "data/maps/PetalburgCity/events.inc" for reading)*

------
https://chatgpt.com/codex/tasks/task_e_68bd590ce8cc8329af959754edbb682a