### PR TITLE
Fix PC MIDI build rule and assembler include path

### DIFF
--- a/MPlayDef.s
+++ b/MPlayDef.s
@@ -1,0 +1,1 @@
+.include "sound/MPlayDef.s"

--- a/Makefile
+++ b/Makefile
@@ -270,19 +270,19 @@ $(PC_OBJ_DIR)/%.o: %.c
 # Convert MIDI files into objects for the PC build.
 $(PC_OBJ_DIR)/sound/songs/midi/%.o: sound/songs/midi/%.mid
 	mkdir -p $(dir $@)
-	$(PREPROC) $< charmap.txt | $(MID) -o $(PC_OBJ_DIR)/sound/songs/midi/$*.s -
+	$(MID) $< $(PC_OBJ_DIR)/sound/songs/midi/$*.s
 	$(PREPROC) $(PC_OBJ_DIR)/sound/songs/midi/$*.s charmap.txt | \
-        $(CPP) $(INCLUDE_SCANINC_ARGS) -Isound -DMODERN=$(MODERN) -DPLATFORM_PC -DUSE_SDL -D__INTELLISENSE__ $(SDL_CFLAGS) - | \
+	$(CPP) $(INCLUDE_SCANINC_ARGS) -Isound -DMODERN=$(MODERN) -DPLATFORM_PC -DUSE_SDL -D__INTELLISENSE__ $(SDL_CFLAGS) - | \
 	$(PREPROC) -ie $(PC_OBJ_DIR)/sound/songs/midi/$*.s charmap.txt | \
-	$(HOSTCC) -c -x assembler -o $@ -
+	$(HOSTCC) -c -x assembler -Wa,-Isound -o $@ -
 
 # Assemble data sources for the PC build.
 $(PC_OBJ_DIR)/%.o: %.s
 	mkdir -p $(dir $@)
 	$(PREPROC) $< charmap.txt | \
-        $(CPP) $(INCLUDE_SCANINC_ARGS) -Isound -DMODERN=$(MODERN) -DPLATFORM_PC -DUSE_SDL -D__INTELLISENSE__ $(SDL_CFLAGS) - | \
+	$(CPP) $(INCLUDE_SCANINC_ARGS) -Isound -DMODERN=$(MODERN) -DPLATFORM_PC -DUSE_SDL -D__INTELLISENSE__ $(SDL_CFLAGS) - | \
 	$(PREPROC) -ie $< charmap.txt | \
-	$(HOSTCC) -c -x assembler -o $@ -
+	$(HOSTCC) -c -x assembler -Wa,-Isound -o $@ -
 
 # Other rules
 rom: $(ROM)


### PR DESCRIPTION
## Summary
- convert PC MIDI targets directly with mid2agb
- search the sound directory when assembling PC objects
- provide a root MPlayDef.s stub so existing includes work on PC

## Testing
- `make build/pc/sound/songs/se_dex_page.o`
- `make build/pc/sound/songs/midi/mus_abandoned_ship.o`


------
https://chatgpt.com/codex/tasks/task_e_68bd5e3952908329b804a962c6e0a576