### PR TITLE
Add PC audio stubs to allow 'make pc' to link

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,7 @@ endif
 # Collect sources
 C_SRCS_IN := $(wildcard $(C_SUBDIR)/*.c $(C_SUBDIR)/*/*.c $(C_SUBDIR)/*/*/*.c)
 C_SRCS := $(foreach src,$(C_SRCS_IN),$(if $(findstring .inc.c,$(src)),,$(src)))
-C_SRCS := $(filter-out $(C_SUBDIR)/pc_bios.c $(C_SUBDIR)/pc_io_reg.c $(C_SUBDIR)/pc_main.c $(C_SUBDIR)/pc_audio.c $(C_SUBDIR)/pc_multiboot.c $(C_SUBDIR)/pc_rtc.c $(C_SUBDIR)/libgcnmultiboot.c,$(C_SRCS))
+C_SRCS := $(filter-out $(C_SUBDIR)/pc_bios.c $(C_SUBDIR)/pc_io_reg.c $(C_SUBDIR)/pc_main.c $(C_SUBDIR)/pc_audio.c $(C_SUBDIR)/pc_multiboot.c $(C_SUBDIR)/pc_rtc.c $(C_SUBDIR)/libgcnmultiboot.c $(C_SUBDIR)/pc_m4a_stub.c,$(C_SRCS))
 C_OBJS := $(patsubst $(C_SUBDIR)/%.c,$(C_BUILDDIR)/%.o,$(C_SRCS))
 
 C_ASM_SRCS := $(wildcard $(C_SUBDIR)/*.s $(C_SUBDIR)/*/*.s $(C_SUBDIR)/*/*/*.s)

--- a/src/m4a_tables.c
+++ b/src/m4a_tables.c
@@ -1,5 +1,6 @@
 #include "gba/m4a_internal.h"
 
+#if PLATFORM_GBA
 // Some of these functions have different signatures, so we need to make this
 // an array of void pointers or a struct. It's simpler to just make it an array
 // for now.
@@ -42,6 +43,7 @@ void *const gMPlayJumpTableTemplate[] =
     RealClearChain,
     SoundMainBTM,
 };
+#endif // PLATFORM_GBA
 
 // This is a table of deltas between sample values in compressed PCM data.
 const s8 gDeltaEncodingTable[] =

--- a/src/m4a_tables.c
+++ b/src/m4a_tables.c
@@ -1,3 +1,4 @@
+#include "platform.h"
 #include "gba/m4a_internal.h"
 
 #if PLATFORM_GBA

--- a/src/pc_m4a_stub.c
+++ b/src/pc_m4a_stub.c
@@ -1,0 +1,27 @@
+#include "global.h"
+#include "gba/m4a_internal.h"
+#include <string.h>
+
+#if PLATFORM_PC
+char gNumMusicPlayers = 4;
+char gMaxLines = 0;
+char SoundMainRAM[0x800];
+
+void SoundMain(void) {}
+void MPlayJumpTableCopy(MPlayFunc *mplayJumpTable) { memset(mplayJumpTable, 0, sizeof(MPlayFunc) * 36); }
+void TrackStop(struct MusicPlayerInfo *mplayInfo, struct MusicPlayerTrack *track) {}
+void FadeOutBody(struct MusicPlayerInfo *mplayInfo) {}
+void TrkVolPitSet(struct MusicPlayerInfo *mplayInfo, struct MusicPlayerTrack *track) {}
+void MPlayOpen(struct MusicPlayerInfo *mplayInfo, struct MusicPlayerTrack *tracks, u8 trackCount) {}
+void MPlayStart(struct MusicPlayerInfo *mplayInfo, struct SongHeader *songHeader) {}
+void Clear64byte(void *addr) { memset(addr, 0, 64); }
+void CgbSound(void) {}
+void CgbOscOff(u8 ch) {}
+u32 MidiKeyToCgbFreq(u8 a, u8 b, u8 c) { return 0; }
+void ply_memacc(struct MusicPlayerInfo *mplayInfo, struct MusicPlayerTrack *track) {}
+void ply_lfos(struct MusicPlayerInfo *mplayInfo, struct MusicPlayerTrack *track) {}
+void ply_mod(struct MusicPlayerInfo *mplayInfo, struct MusicPlayerTrack *track) {}
+void ply_xcmd(struct MusicPlayerInfo *mplayInfo, struct MusicPlayerTrack *track) {}
+void ply_endtie(struct MusicPlayerInfo *mplayInfo, struct MusicPlayerTrack *track) {}
+void ply_note(u32 note_cmd, struct MusicPlayerInfo *mplayInfo, struct MusicPlayerTrack *track) {}
+#endif


### PR DESCRIPTION
## Summary
- avoid GBA-only jump table on the PC build
- exclude PC audio stubs from GBA builds
- provide no-op implementations of m4a routines for PC

## Testing
- `make pc` *(fails: tools/mapjson/mapjson: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bd73a402fc8329a11820f4753535b6