### PR TITLE
Fix PC build stubs and assembly for host

### DIFF
--- a/src/pc_m4a_stub.c
+++ b/src/pc_m4a_stub.c
@@ -24,4 +24,19 @@ void ply_mod(struct MusicPlayerInfo *mplayInfo, struct MusicPlayerTrack *track) 
 void ply_xcmd(struct MusicPlayerInfo *mplayInfo, struct MusicPlayerTrack *track) {}
 void ply_endtie(struct MusicPlayerInfo *mplayInfo, struct MusicPlayerTrack *track) {}
 void ply_note(u32 note_cmd, struct MusicPlayerInfo *mplayInfo, struct MusicPlayerTrack *track) {}
+void ply_xxx(struct MusicPlayerInfo *mplayInfo, struct MusicPlayerTrack *track) {}
+void ply_xwave(struct MusicPlayerInfo *mplayInfo, struct MusicPlayerTrack *track) {}
+void ply_xtype(struct MusicPlayerInfo *mplayInfo, struct MusicPlayerTrack *track) {}
+void ply_xatta(struct MusicPlayerInfo *mplayInfo, struct MusicPlayerTrack *track) {}
+void ply_xdeca(struct MusicPlayerInfo *mplayInfo, struct MusicPlayerTrack *track) {}
+void ply_xsust(struct MusicPlayerInfo *mplayInfo, struct MusicPlayerTrack *track) {}
+void ply_xrele(struct MusicPlayerInfo *mplayInfo, struct MusicPlayerTrack *track) {}
+void ply_xiecv(struct MusicPlayerInfo *mplayInfo, struct MusicPlayerTrack *track) {}
+void ply_xiecl(struct MusicPlayerInfo *mplayInfo, struct MusicPlayerTrack *track) {}
+void ply_xleng(struct MusicPlayerInfo *mplayInfo, struct MusicPlayerTrack *track) {}
+void ply_xswee(struct MusicPlayerInfo *mplayInfo, struct MusicPlayerTrack *track) {}
+void ply_xcmd_0C(struct MusicPlayerInfo *mplayInfo, struct MusicPlayerTrack *track) {}
+void ply_xcmd_0D(struct MusicPlayerInfo *mplayInfo, struct MusicPlayerTrack *track) {}
+bool32 IsPokemonCryPlaying(struct MusicPlayerInfo *mplayInfo) { return FALSE; }
+u32 umul3232H32(u32 multiplier, u32 multiplicand) { return (u32)(((u64)multiplier * multiplicand) >> 32); }
 #endif

--- a/src/pc_stub.c
+++ b/src/pc_stub.c
@@ -1,0 +1,8 @@
+#include "global.h"
+#include "main.h"
+
+#if PLATFORM_PC
+u32 IntrMain[0x200] = {0};
+const u8 RomHeaderGameCode[GAME_CODE_LENGTH] = {0};
+const u8 RomHeaderSoftwareVersion = 0;
+#endif


### PR DESCRIPTION
## Summary
- Add host-specific stubs and linker exclusions for PC build
- Fix `.word` assembler directives for host builds
- Provide platform constants and interrupt vector stubs

## Testing
- `make pc` *(fails: interrupted due to environment constraints, see logs)*

------
https://chatgpt.com/codex/tasks/task_e_68bd78d288608329a2414a5762040511