### PR TITLE
Fix PC M4A symbol types

### DIFF
--- a/include/gba/m4a_internal.h
+++ b/include/gba/m4a_internal.h
@@ -407,8 +407,19 @@ extern const struct PokemonCrySong gPokemonCrySongTemplate;
 
 extern const struct ToneData voicegroup_dummy;
 
+// gNumMusicPlayers and gMaxLines are defined differently on the
+// GBA and the PC builds. On hardware these symbols are given constant
+// values by the linker script and are declared as arrays of char so that
+// their addresses evaluate to the desired numeric value when cast. For
+// the PC version we simply expose them as regular variables holding the
+// numeric values directly.
+#if PLATFORM_PC
+extern u16 gNumMusicPlayers;
+extern u32 gMaxLines;
+#else
 extern char gNumMusicPlayers[];
 extern char gMaxLines[];
+#endif
 
 #define NUM_MUSIC_PLAYERS ((u16)gNumMusicPlayers)
 #define MAX_LINES ((u32)gMaxLines)

--- a/src/pc_m4a_stub.c
+++ b/src/pc_m4a_stub.c
@@ -3,8 +3,12 @@
 #include <string.h>
 
 #if PLATFORM_PC
-char gNumMusicPlayers = 4;
-char gMaxLines = 0;
+// When building the game for PC we need concrete storage for a few of
+// the symbols that are normally resolved by the GBA linker script. The
+// music player count and max lines are simple scalar values instead of
+// linker constants, so expose them as regular variables.
+u16 gNumMusicPlayers = 4;
+u32 gMaxLines = 0;
 char SoundMainRAM[0x800];
 
 void SoundMain(void) {}


### PR DESCRIPTION
## Summary
- declare gNumMusicPlayers and gMaxLines as scalar variables when building on PC
- adjust pc M4A stub to define those variables for the host build

## Testing
- `make pc` *(fails: build interrupted after long compile, but invocation attempted)*

------
https://chatgpt.com/codex/tasks/task_e_68bd7c6f4e9c832990a810ea569b096a