### PR TITLE
Guard RFU code for PC build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -225,8 +225,8 @@ OBJS_REL := $(patsubst $(OBJ_DIR)/%,%,$(OBJS))
 # Objects for the desktop PC build. Use the host compiler and include the
 # emulator BIOS and I/O stubs. Remove objects that rely on the GBA CPU.
 PC_OBJ_DIR := $(BUILD_DIR)/pc
-PC_OBJS := $(addprefix $(PC_OBJ_DIR)/,$(filter-out src/crt0.o src/m4a.o src/m4a_1.o src/rom_header.o src/librfu_intr.o src/librfu_rfu.o src/librfu_sio32id.o src/librfu_stwi.o src/multiboot.o src/platform/io_stub.o src/pc_multiboot.o src/libgcnmultiboot.o src/siirtc.o,$(OBJS_REL)))
-PC_OBJS += $(PC_OBJ_DIR)/src/pc_bios.o $(PC_OBJ_DIR)/src/pc_main.o $(PC_OBJ_DIR)/src/pc_audio.o $(PC_OBJ_DIR)/src/pc_io_reg.o $(PC_OBJ_DIR)/src/pc_multiboot.o $(PC_OBJ_DIR)/src/pc_rtc.o $(PC_OBJ_DIR)/src/pc_m4a_stub.o $(PC_OBJ_DIR)/src/libgcnmultiboot.o $(PC_OBJ_DIR)/src/pc_stub.o $(PC_OBJ_DIR)/libagbsyscall/libagbsyscall.o
+PC_OBJS := $(addprefix $(PC_OBJ_DIR)/,$(filter-out src/crt0.o src/m4a.o src/m4a_1.o src/rom_header.o src/librfu_intr.o src/librfu_rfu.o src/librfu_sio32id.o src/librfu_stwi.o src/multiboot.o src/platform/io_stub.o src/pc_multiboot.o src/libgcnmultiboot.o src/siirtc.o src/AgbRfu_LinkManager.o src/link_rfu_2.o src/link_rfu_3.o src/trade.o src/union_room.o src/wireless_communication_status_screen.o,$(OBJS_REL)))
+PC_OBJS += $(PC_OBJ_DIR)/src/pc_bios.o $(PC_OBJ_DIR)/src/pc_main.o $(PC_OBJ_DIR)/src/pc_audio.o $(PC_OBJ_DIR)/src/pc_io_reg.o $(PC_OBJ_DIR)/src/pc_multiboot.o $(PC_OBJ_DIR)/src/pc_rtc.o $(PC_OBJ_DIR)/src/pc_m4a_stub.o $(PC_OBJ_DIR)/src/libgcnmultiboot.o $(PC_OBJ_DIR)/libagbsyscall/libagbsyscall.o
 PKG_CONFIG := $(shell which pkg-config 2>/dev/null)
 ifeq ($(PKG_CONFIG),)
   ifeq ($(SDL_CFLAGS),)

--- a/src/link.c
+++ b/src/link.c
@@ -236,6 +236,7 @@ static const u8 sUnusedData[] = {0x00, 0xFF, 0xFE, 0xFF, 0x00};
 
 bool8 IsWirelessAdapterConnected(void)
 {
+#if !PLATFORM_PC
     SetWirelessCommType1();
     InitRFUAPI();
     if (rfu_LMAN_REQBN_softReset_and_checkID() == RFU_ID)
@@ -247,6 +248,7 @@ bool8 IsWirelessAdapterConnected(void)
     SetWirelessCommType0_Internal();
     CloseLink();
     RestoreSerialTimer3IntrHandlers();
+#endif
     return FALSE;
 }
 
@@ -386,7 +388,9 @@ void OpenLink(void)
     }
     else
     {
+#if !PLATFORM_PC
         InitRFUAPI();
+#endif
     }
     gReceivedRemoteLinkPlayers = 0;
     for (i = 0; i < MAX_LINK_PLAYERS; i++)
@@ -1715,8 +1719,10 @@ static void CB2_PrintErrorMessage(void)
         {
             if (JOY_NEW(A_BUTTON))
             {
+#if !PLATFORM_PC
                 rfu_REQ_stopMode();
                 rfu_waitREQComplete();
+#endif
                 DoSoftReset();
             }
         }

--- a/src/main.c
+++ b/src/main.c
@@ -107,7 +107,9 @@ void AgbMain(void)
     InitIntrHandlers();
     m4aSoundInit();
     EnableVCountIntrAtLine150();
+#if !PLATFORM_PC
     InitRFU();
+#endif
     RtcInit();
     CheckForFlashMemory();
     InitMainCallbacks();
@@ -143,8 +145,10 @@ void AgbMain(void)
          && JOY_HELD_RAW(A_BUTTON)
          && JOY_HELD_RAW(B_START_SELECT) == B_START_SELECT)
         {
+#if !PLATFORM_PC
             rfu_REQ_stopMode();
             rfu_waitREQComplete();
+#endif
             DoSoftReset();
         }
 


### PR DESCRIPTION
## Summary
- avoid building RFU and other GBA-only sources for the PC target
- guard RFU-specific calls in main and link when compiling for PC

## Testing
- `make generated`
- `make pc` *(fails: produced excessive warnings and aborted before confirming success)*

------
https://chatgpt.com/codex/tasks/task_e_68bd805965e08329a55e5c8ff1ca0735