### PR TITLE
Fix PC build assembly macros

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -269,7 +269,7 @@ modern: all
 compare: all
 
 # Build a desktop executable when PLATFORM_PC is defined.
-SED_PC_CONV := sed -e 's/\\.word/\\.long/g' -e 's/\\.4byte/\\.long/g' -e 's/\\.2byte/\\.short/g'
+SED_PC_CONV := sed -e 's/\\.word/\\.long/g' -e 's/\\.4byte/\\.long/g' -e 's/\\.2byte/\\.short/g' -e 's/@.*//'
 pc: generated $(BUILD_DIR)/pc/pokeemerald
 
 $(BUILD_DIR)/pc/pokeemerald: $(PC_OBJS)

--- a/asm/macros/movement.inc
+++ b/asm/macros/movement.inc
@@ -1,17 +1,18 @@
-	.macro create_movement_action name:req, value:req
-	.macro \name
-	.byte \value
-	.endm
-	.endm
+        .macro create_movement_action name:req, value:req
+        .macro \name
+        .byte \value
+        .endm
+        .endm
 
-	create_movement_action face_down, MOVEMENT_ACTION_FACE_DOWN
-	create_movement_action face_up, MOVEMENT_ACTION_FACE_UP
-	create_movement_action face_left, MOVEMENT_ACTION_FACE_LEFT
-	create_movement_action face_right, MOVEMENT_ACTION_FACE_RIGHT
-	create_movement_action walk_slow_down, MOVEMENT_ACTION_WALK_SLOW_DOWN
-	create_movement_action walk_slow_up, MOVEMENT_ACTION_WALK_SLOW_UP
-	create_movement_action walk_slow_left, MOVEMENT_ACTION_WALK_SLOW_LEFT
-	create_movement_action walk_slow_right, MOVEMENT_ACTION_WALK_SLOW_RIGHT
+#ifdef MOVEMENT_ACTION_FACE_DOWN
+        create_movement_action face_down, MOVEMENT_ACTION_FACE_DOWN
+        create_movement_action face_up, MOVEMENT_ACTION_FACE_UP
+        create_movement_action face_left, MOVEMENT_ACTION_FACE_LEFT
+        create_movement_action face_right, MOVEMENT_ACTION_FACE_RIGHT
+        create_movement_action walk_slow_down, MOVEMENT_ACTION_WALK_SLOW_DOWN
+        create_movement_action walk_slow_up, MOVEMENT_ACTION_WALK_SLOW_UP
+        create_movement_action walk_slow_left, MOVEMENT_ACTION_WALK_SLOW_LEFT
+        create_movement_action walk_slow_right, MOVEMENT_ACTION_WALK_SLOW_RIGHT
 	create_movement_action walk_down, MOVEMENT_ACTION_WALK_NORMAL_DOWN
 	create_movement_action walk_up, MOVEMENT_ACTION_WALK_NORMAL_UP
 	create_movement_action walk_left, MOVEMENT_ACTION_WALK_NORMAL_LEFT
@@ -163,4 +164,5 @@
 	create_movement_action fly_up, MOVEMENT_ACTION_FLY_UP
 	create_movement_action fly_down, MOVEMENT_ACTION_FLY_DOWN
 
-	create_movement_action step_end, MOVEMENT_ACTION_STEP_END
+        create_movement_action step_end, MOVEMENT_ACTION_STEP_END
+#endif


### PR DESCRIPTION
## Summary
- strip ARM-style `@` comments when assembling for PC
- guard movement action macro definitions behind movement constant checks

## Testing
- `tools/preproc/preproc data/battle_scripts_1.s charmap.txt | cc -E -I include -Isound -DMODERN=0 -DPLATFORM_PC -DUSE_SDL -D__INTELLISENSE__ -I/usr/include/SDL2 -D_REENTRANT - | tools/preproc/preproc -ie data/battle_scripts_1.s charmap.txt | sed -e 's/\.word/\.long/g' -e 's/\.4byte/\.long/g' -e 's/\.2byte/\.short/g' -e 's/@.*//' | gcc -fno-pie -c -x assembler -Wa,-Isound -o build/pc/data/battle_scripts_1.o -`

------
https://chatgpt.com/codex/tasks/task_e_68bd9a03b72c83299463db0d26bd337e