### PR TITLE
Strip ARM comments in PC assembly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -269,7 +269,7 @@ modern: all
 compare: all
 
 # Build a desktop executable when PLATFORM_PC is defined.
-SED_PC_CONV := sed -e 's/\\.word/\\.long/g' -e 's/\\.4byte/\\.long/g' -e 's/\\.2byte/\\.short/g'
+SED_PC_CONV := sed -e 's/\\.word/\\.long/g' -e 's/\\.4byte/\\.long/g' -e 's/\\.2byte/\\.short/g' -e 's/@.*$$//'
 pc: generated $(BUILD_DIR)/pc/pokeemerald
 
 $(BUILD_DIR)/pc/pokeemerald: $(PC_OBJS)


### PR DESCRIPTION
## Summary
- sanitize PC assembly sources by stripping `@` comments during preprocessing

## Testing
- `make build/pc/data/field_effect_scripts.o`
- `make pc` *(fails: build interrupted after extensive compilation output)*

------
https://chatgpt.com/codex/tasks/task_e_68bda18cd90883298a35588f081485f7