### PR TITLE
Fix missing declarations in TryUseNextRepel

### DIFF
--- a/src/wild_encounter.c
+++ b/src/wild_encounter.c
@@ -19,10 +19,12 @@
 #include "item.h"
 #include "item_menu.h"
 #include "sound.h"
+#include "string_util.h"
 #include "constants/abilities.h"
 #include "constants/game_stat.h"
 #include "constants/items.h"
 #include "constants/layouts.h"
+#include "constants/songs.h"
 #include "constants/weather.h"
 
 extern const u8 EventScript_RepelWoreOff[];


### PR DESCRIPTION
## Summary
- include string_util.h for gStringVar2
- include constants/songs.h for SE_REPEL

## Testing
- `make -j2` *(fails: tools/agbcc/bin/agbcc: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c40f226f8c832998c0c672d8ab4235