### PR TITLE
Handle missing REROLL_SHINY definition

### DIFF
--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -2210,7 +2210,11 @@ void CreateBoxMon(struct BoxPokemon *boxMon, u16 species, u8 level, u8 fixedIV, 
     u32 otId;
     u32 value;
     u16 checksum;
+#ifdef REROLL_SHINY
     s32 shinyRerolls = REROLL_SHINY;
+#else
+    s32 shinyRerolls = 1;
+#endif
     bool32 shinyLocked = (hasFixedPersonality || otIdType != OT_ID_PLAYER_ID);
 
     do


### PR DESCRIPTION
## Summary
- Ensure `CreateBoxMon` uses a default shiny reroll count when `REROLL_SHINY` is undefined

## Testing
- `make` *(fails: arm-none-eabi-as: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c42aa1a0e48329a266e95a63522937